### PR TITLE
Bugfix/hotspot onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-redux": "^7.2.2",
     "redux-thunk": "^2.3.0",
     "rn-sliding-up-panel": "^2.4.4",
+    "use-debounce": "^5.2.0",
     "use-state-with-callback": "^2.0.3",
     "validator": "^13.5.1"
   },

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,6 +7,7 @@ import Text from './Text'
 import { Colors, Theme } from '../theme/theme'
 import TouchableOpacityBox from './TouchableOpacityBox'
 import Box from './Box'
+import WithDebounce from './WithDebounce'
 
 type Props = BoxProps<Theme> & {
   mode?: 'text' | 'contained'
@@ -86,3 +87,5 @@ const Button = ({
 }
 
 export default Button
+
+export const DebouncedButton = WithDebounce(Button)

--- a/src/components/HotspotPairingList.tsx
+++ b/src/components/HotspotPairingList.tsx
@@ -3,7 +3,7 @@ import { FlatList, Image } from 'react-native'
 import { Device } from 'react-native-ble-plx'
 import Box from './Box'
 import Text from './Text'
-import TouchableOpacityBox from './TouchableOpacityBox'
+import { DebouncedTouchableOpacityBox } from './TouchableOpacityBox'
 import { useColors, useSpacing } from '../theme/themeHooks'
 import CarotRight from '../assets/images/carot-right.svg'
 import HeliumHotspot from '../assets/images/helium-hotspot.svg'
@@ -74,7 +74,7 @@ const HotspotPairingItem = ({
     }
   }
   return (
-    <TouchableOpacityBox
+    <DebouncedTouchableOpacityBox
       disabled={disabled}
       onPress={() => onPress(hotspot)}
       backgroundColor="white"
@@ -101,7 +101,7 @@ const HotspotPairingItem = ({
         </Text>
       </Box>
       <CarotRight color={colors.grayLight} />
-    </TouchableOpacityBox>
+    </DebouncedTouchableOpacityBox>
   )
 }
 

--- a/src/components/TouchableHighlightBox.tsx
+++ b/src/components/TouchableHighlightBox.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createBox } from '@shopify/restyle'
 import { TouchableHighlight, TouchableHighlightProps } from 'react-native'
 import { Theme } from '../theme/theme'
+import WithDebounce from './WithDebounce'
 
 const TouchableHighlightBox = createBox<
   Theme,
@@ -15,3 +16,7 @@ export default TouchableHighlightBox
 export type TouchableHighlightBoxProps = React.ComponentProps<
   typeof TouchableHighlightBox
 >
+
+export const DebouncedTouchableHighlightBox = WithDebounce(
+  TouchableHighlightBox,
+)

--- a/src/components/TouchableOpacityBox.tsx
+++ b/src/components/TouchableOpacityBox.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createBox } from '@shopify/restyle'
 import { TouchableOpacity, TouchableOpacityProps } from 'react-native'
 import { Theme } from '../theme/theme'
+import WithDebounce from './WithDebounce'
 
 const TouchableOpacityBox = createBox<
   Theme,
@@ -15,3 +16,4 @@ export default TouchableOpacityBox
 export type TouchableOpacityBoxProps = React.ComponentProps<
   typeof TouchableOpacityBox
 >
+export const DebouncedTouchableOpacityBox = WithDebounce(TouchableOpacityBox)

--- a/src/components/WithDebounce.tsx
+++ b/src/components/WithDebounce.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { GestureResponderEvent } from 'react-native'
+import { useDebouncedCallback } from 'use-debounce'
+
+type DebounceProps = {
+  onPress?: (event: GestureResponderEvent) => void
+  children?: React.ReactNode
+  duration?: number
+}
+
+export default function WithDebounce<T>(Component: React.FC<T>) {
+  return function WithDebounceComponent({
+    onPress,
+    duration,
+    ...props
+  }: T & DebounceProps) {
+    const debouncedHandler = useDebouncedCallback(
+      (event: GestureResponderEvent) => onPress?.(event),
+      duration || 300,
+      { leading: true, trailing: false },
+    )
+
+    // TODO: Someday when time is aplenty, fix the TS warning.
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <Component {...props} onPress={debouncedHandler.callback} />
+  }
+}

--- a/src/features/hotspots/setup/HotspotSelectionScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSelectionScreen.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import BackScreen from '../../../components/BackScreen'
 import Box from '../../../components/Box'
 import Card from '../../../components/Card'
 import Text from '../../../components/Text'
-import TouchableHighlightBox from '../../../components/TouchableHighlightBox'
+import { DebouncedTouchableHighlightBox } from '../../../components/TouchableHighlightBox'
 import { HotspotSetupNavigationProp } from './hotspotSetupTypes'
 import Hotspot from '../../../assets/images/hotspot.svg'
 import RAK from '../../../assets/images/rak.svg'
@@ -18,6 +18,15 @@ const HotspotSetupSelectionScreen = () => {
   const { purpleMain } = useColors()
   const [pressing, setPressing] = useState<HotspotType | undefined>()
   const colors = useColors()
+
+  const navNext = useCallback(
+    (hotspotType: HotspotType) => () => {
+      navigation.push('HotspotSetupEducationScreen', {
+        hotspotType,
+      })
+    },
+    [navigation],
+  )
 
   return (
     <BackScreen backgroundColor="primaryBackground" padding="lx">
@@ -34,18 +43,14 @@ const HotspotSetupSelectionScreen = () => {
 
       <Box flexDirection="row" height={191} marginTop="s">
         <Card flex={1} variant="elevated" backgroundColor="white">
-          <TouchableHighlightBox
+          <DebouncedTouchableHighlightBox
             height="100%"
             width="100%"
             borderRadius="m"
             underlayColor={purpleMain}
             onPressIn={() => setPressing('Helium')}
             onPressOut={() => setPressing(undefined)}
-            onPress={() =>
-              navigation.push('HotspotSetupEducationScreen', {
-                hotspotType: 'Helium',
-              })
-            }
+            onPress={navNext('Helium')}
             alignItems="center"
             justifyContent="center"
           >
@@ -67,24 +72,20 @@ const HotspotSetupSelectionScreen = () => {
                 {t('hotspot_setup.selection.option_one')}
               </Text>
             </>
-          </TouchableHighlightBox>
+          </DebouncedTouchableHighlightBox>
         </Card>
 
         <Box marginRight="ms" />
 
         <Card flex={1} variant="elevated" backgroundColor="white">
-          <TouchableHighlightBox
+          <DebouncedTouchableHighlightBox
             height="100%"
             width="100%"
             borderRadius="m"
             underlayColor={purpleMain}
             onPressIn={() => setPressing('RAK')}
             onPressOut={() => setPressing(undefined)}
-            onPress={() =>
-              navigation.push('HotspotSetupEducationScreen', {
-                hotspotType: 'RAK',
-              })
-            }
+            onPress={navNext('RAK')}
             alignItems="center"
             justifyContent="center"
           >
@@ -106,7 +107,7 @@ const HotspotSetupSelectionScreen = () => {
                 {t('hotspot_setup.selection.option_two')}
               </Text>
             </>
-          </TouchableHighlightBox>
+          </DebouncedTouchableHighlightBox>
         </Card>
       </Box>
       <Box flex={1.5} />

--- a/src/features/hotspots/setup/HotspotSetupBluetoothInfoScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupBluetoothInfoScreen.tsx
@@ -3,7 +3,7 @@ import { Linking, Platform } from 'react-native'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import BackScreen from '../../../components/BackScreen'
-import Button from '../../../components/Button'
+import { DebouncedButton } from '../../../components/Button'
 import Text from '../../../components/Text'
 import {
   HotspotSetupNavigationProp,
@@ -106,7 +106,7 @@ const HotspotSetupBluetoothInfoScreen = () => {
         {subtitle2}
       </Text>
       <Box flex={1} width="100%" justifyContent="flex-end">
-        <Button
+        <DebouncedButton
           width="100%"
           variant="primary"
           mode="contained"

--- a/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
+++ b/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Device } from 'react-native-ble-plx'
+import { useDebouncedCallback } from 'use-debounce'
 import Box from '../../../components/Box'
 import HotspotPairingList from '../../../components/HotspotPairingList'
 import Text from '../../../components/Text'
@@ -14,11 +15,15 @@ const HotspotSetupBluetoothSuccess = () => {
   const navigation = useNavigation<HotspotSetupNavigationProp>()
   const { availableHotspots } = useConnectedHotspotContext()
 
-  const handleConnect = async (hotspot: Device) => {
-    navigation.replace('HotspotSetupConnectingScreen', {
-      hotspotId: hotspot.id,
-    })
-  }
+  const handleConnect = useDebouncedCallback(
+    (hotspot: Device) => {
+      navigation.replace('HotspotSetupConnectingScreen', {
+        hotspotId: hotspot.id,
+      })
+    },
+    1000,
+    { leading: true },
+  )
 
   return (
     <Box flex={1}>
@@ -43,7 +48,7 @@ const HotspotSetupBluetoothSuccess = () => {
       <Box flex={1} paddingHorizontal="lx" backgroundColor="purple200">
         <HotspotPairingList
           hotspots={Object.values(availableHotspots)}
-          onPress={handleConnect}
+          onPress={handleConnect.callback}
         />
       </Box>
     </Box>

--- a/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
+++ b/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
@@ -2,7 +2,6 @@ import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Device } from 'react-native-ble-plx'
-import { useDebouncedCallback } from 'use-debounce'
 import Box from '../../../components/Box'
 import HotspotPairingList from '../../../components/HotspotPairingList'
 import Text from '../../../components/Text'
@@ -15,15 +14,11 @@ const HotspotSetupBluetoothSuccess = () => {
   const navigation = useNavigation<HotspotSetupNavigationProp>()
   const { availableHotspots } = useConnectedHotspotContext()
 
-  const handleConnect = useDebouncedCallback(
-    (hotspot: Device) => {
-      navigation.replace('HotspotSetupConnectingScreen', {
-        hotspotId: hotspot.id,
-      })
-    },
-    1000,
-    { leading: true },
-  )
+  const handleConnect = async (hotspot: Device) => {
+    navigation.replace('HotspotSetupConnectingScreen', {
+      hotspotId: hotspot.id,
+    })
+  }
 
   return (
     <Box flex={1}>
@@ -48,7 +43,7 @@ const HotspotSetupBluetoothSuccess = () => {
       <Box flex={1} paddingHorizontal="lx" backgroundColor="purple200">
         <HotspotPairingList
           hotspots={Object.values(availableHotspots)}
-          onPress={handleConnect.callback}
+          onPress={handleConnect}
         />
       </Box>
     </Box>

--- a/src/features/hotspots/setup/HotspotSetupDiagnosticsScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupDiagnosticsScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView } from 'react-native'
 import BackScreen from '../../../components/BackScreen'
-import Button from '../../../components/Button'
+import { DebouncedButton } from '../../../components/Button'
 import Text from '../../../components/Text'
 import TextTransform from '../../../components/TextTransform'
 import {
@@ -43,7 +43,7 @@ const HotspotSetupDiagnosticsScreen = () => {
           i18nKey="hotspot_setup.diagnostics.p_1"
         />
       </ScrollView>
-      <Button
+      <DebouncedButton
         variant="primary"
         mode="contained"
         title={t('generic.understand')}

--- a/src/features/hotspots/setup/HotspotSetupEducationScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupEducationScreen.tsx
@@ -7,7 +7,7 @@ import Box from '../../../components/Box'
 import Text from '../../../components/Text'
 import slides from './hotspotSetupSlides'
 import { wp } from '../../../utils/layout'
-import Button from '../../../components/Button'
+import { DebouncedButton } from '../../../components/Button'
 import CarouselItem, {
   CarouselItemData,
 } from '../../../components/CarouselItem'
@@ -37,7 +37,7 @@ const HotspotEducationScreen = () => {
   const renderButton = () => {
     if (viewedSlides) {
       return (
-        <Button
+        <DebouncedButton
           onPress={navNext}
           variant="primary"
           mode="contained"
@@ -46,7 +46,7 @@ const HotspotEducationScreen = () => {
       )
     }
     return (
-      <Button
+      <DebouncedButton
         variant="secondary"
         mode="text"
         onPress={navNext}

--- a/src/features/hotspots/setup/HotspotSetupPowerScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupPowerScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { Platform } from 'react-native'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import BackScreen from '../../../components/BackScreen'
-import Button from '../../../components/Button'
+import { DebouncedButton } from '../../../components/Button'
 import Text from '../../../components/Text'
 import {
   HotspotSetupNavigationProp,
@@ -26,6 +26,11 @@ const HotspotSetupPowerScreen = () => {
   )
   const subtitle2 = t(
     `hotspot_setup.power.${hotspotType === 'RAK' ? 'rak_' : ''}subtitle_2`,
+  )
+
+  const navNext = useCallback(
+    () => navigation.push('HotspotSetupBluetoothInfoScreen', { hotspotType }),
+    [navigation, hotspotType],
   )
 
   useEffect(() => {
@@ -64,15 +69,13 @@ const HotspotSetupPowerScreen = () => {
       <Text marginBottom="xl" variant="subtitle" textAlign="center">
         {subtitle2}
       </Text>
-      <Button
+      <DebouncedButton
         marginTop="xxl"
         width="100%"
         variant="secondary"
         mode="contained"
         title={t('hotspot_setup.power.next')}
-        onPress={() =>
-          navigation.push('HotspotSetupBluetoothInfoScreen', { hotspotType })
-        }
+        onPress={navNext}
       />
     </BackScreen>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -11620,6 +11620,11 @@ url-parse@^1.4.4:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-debounce@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.2.0.tgz#3cb63f5c46f40092c570356e441dbc016ffb2f8b"
+  integrity sha512-lW4tbPsTnvPKYqOYXp5xZ7SP7No/ARLqqQqoyRKuSzP0HxR9arhSAhznXUZFoNPWDRij8fog+N6sYbjb8c3kzw==
+
 use-state-with-callback@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/use-state-with-callback/-/use-state-with-callback-2.0.3.tgz#3be56ca52b6afcfe364e0579749dfe588c47c01f"


### PR DESCRIPTION
During hotspot onboarding, it was possible to double click any of the buttons which would cause various errors along the way.

This PR creates a higher-order component that debounces button clicks. I've created "debounced" versions of our buttons and converted the hotspot onboarding process to use them.