### PR TITLE
Add support for ENS addresses

### DIFF
--- a/src/features/moreTab/more/MoreScreen.tsx
+++ b/src/features/moreTab/more/MoreScreen.tsx
@@ -203,7 +203,8 @@ const MoreScreen = () => {
         data: [
           {
             title: t('more.sections.learn.tokenEarnings'),
-            openUrl: 'https://docs.helium.com/blockchain/mining/#how-do-hotspots-earn-helium-tokens',
+            openUrl:
+              'https://docs.helium.com/blockchain/mining/#how-do-hotspots-earn-helium-tokens',
           },
           {
             title: t('more.sections.learn.heliumtoken'),

--- a/src/features/wallet/scan/ScanView.tsx
+++ b/src/features/wallet/scan/ScanView.tsx
@@ -135,11 +135,9 @@ const ScanView = () => {
               >
                 {t('send.scan.send')}
               </Text>
-              <Text marginBottom="xs">
-              {t('send.scan.send_description')}
-              </Text>
+              <Text marginBottom="xs">{t('send.scan.send_description')}</Text>
               <Text variant="body2Bold" color="blueMain">
-              {t('send.scan.learn_more')}
+                {t('send.scan.learn_more')}
               </Text>
             </Box>
             <Box marginBottom="s">
@@ -151,11 +149,9 @@ const ScanView = () => {
               >
                 {t('send.scan.burn')}
               </Text>
-              <Text marginBottom="xs">
-              {t('send.scan.burn_description')}
-              </Text>
+              <Text marginBottom="xs">{t('send.scan.burn_description')}</Text>
               <Text variant="body2Bold" color="blueMain">
-              {t('send.scan.learn_more')}
+                {t('send.scan.learn_more')}
               </Text>
             </Box>
             <Box marginBottom="s">
@@ -167,11 +163,9 @@ const ScanView = () => {
               >
                 {t('send.scan.view')}
               </Text>
-              <Text marginBottom="xs">
-              {t('send.scan.view_description')}
-              </Text>
+              <Text marginBottom="xs">{t('send.scan.view_description')}</Text>
               <Text variant="body2Bold" color="blueMain">
-              {t('send.scan.learn_more')}
+                {t('send.scan.learn_more')}
               </Text>
             </Box>
           </Box>

--- a/src/features/wallet/send/SendForm.tsx
+++ b/src/features/wallet/send/SendForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ScrollView } from 'react-native'
+import { ActivityIndicator, ScrollView } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { Address } from '@helium/crypto-react-native'
 import Balance, { NetworkTokens } from '@helium/currency'
@@ -22,6 +22,8 @@ type Props = {
   isLocked: boolean
   type: SendType
   address: string
+  addressAlias?: string
+  addressLoading?: boolean
   amount: string
   dcAmount: string
   memo: string
@@ -46,6 +48,8 @@ const SendForm = ({
   isSeller,
   type,
   address,
+  addressAlias,
+  addressLoading = false,
   amount,
   dcAmount,
   memo,
@@ -115,21 +119,13 @@ const SendForm = ({
         label={t('send.address.label')}
         placeholder={t('send.address.placeholder')}
         extra={
-          isValidAddress ? (
-            <Box padding="s" position="absolute" right={0}>
-              <Check />
-            </Box>
-          ) : (
-            <TouchableOpacityBox
-              onPress={onScanPress}
-              padding="s"
-              position="absolute"
-              right={0}
-            >
-              <QrCode width={16} color={primaryMain} />
-            </TouchableOpacityBox>
-          )
+          <AddressExtra
+            addressLoading={addressLoading}
+            isValidAddress={isValidAddress}
+            onScanPress={onScanPress}
+          />
         }
+        footer={<AddressAliasFooter addressAlias={addressAlias} />}
       />
       <InputField
         type="numeric"
@@ -298,6 +294,56 @@ const FeeFooter = ({ fee }: { fee: Balance<NetworkTokens> }) => {
         +{fee.toString(8)} {t('generic.fee').toUpperCase()}
       </Text>
     </Box>
+  )
+}
+
+const AddressAliasFooter = ({ addressAlias }: { addressAlias?: string }) => {
+  if (!addressAlias) return null
+
+  return (
+    <Box marginTop="xs">
+      <Text variant="mono" color="grayText" fontSize={11}>
+        {addressAlias}
+      </Text>
+    </Box>
+  )
+}
+
+type AddressExtraProps = {
+  addressLoading?: boolean
+  isValidAddress?: boolean
+  onScanPress: () => void
+}
+const AddressExtra = ({
+  addressLoading,
+  isValidAddress,
+  onScanPress,
+}: AddressExtraProps) => {
+  const colors = useColors()
+
+  if (addressLoading) {
+    return (
+      <Box padding="s" position="absolute" right={0}>
+        <ActivityIndicator />
+      </Box>
+    )
+  }
+  if (isValidAddress) {
+    return (
+      <Box padding="s" position="absolute" right={0}>
+        <Check />
+      </Box>
+    )
+  }
+  return (
+    <TouchableOpacityBox
+      onPress={onScanPress}
+      padding="s"
+      position="absolute"
+      right={0}
+    >
+      <QrCode width={16} color={colors.primaryMain} />
+    </TouchableOpacityBox>
   )
 }
 

--- a/src/features/wallet/send/SendForm.tsx
+++ b/src/features/wallet/send/SendForm.tsx
@@ -324,7 +324,7 @@ const AddressExtra = ({
   if (addressLoading) {
     return (
       <Box padding="s" position="absolute" right={0}>
-        <ActivityIndicator />
+        <ActivityIndicator color="gray" />
       </Box>
     )
   }

--- a/src/features/wallet/send/SendView.tsx
+++ b/src/features/wallet/send/SendView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Alert } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useNavigation } from '@react-navigation/native'
@@ -12,6 +12,7 @@ import { useAsync } from 'react-async-hook'
 import { useSelector } from 'react-redux'
 import { Hotspot } from '@helium/http'
 import { TransferHotspotV1 } from '@helium/transactions'
+import ens from '@ensdomains/ensjs'
 import { RootState } from '../../../store/rootReducer'
 import Box from '../../../components/Box'
 import { triggerNavHaptic } from '../../../utils/haptic'
@@ -386,7 +387,15 @@ const SendView = ({ scanResult, sendType, hotspot, isSeller }: Props) => {
     }
   }
 
-  const handleAmountChange = (stringAmount: string) => {
+  const handleAddressChange = useCallback(async (newAddress: string) => {
+    if (newAddress.match(/.*\.eth$/)) {
+      const ensAddress = await ens.name(newAddress).getAddress()
+      console.log('ens address', ensAddress)
+    }
+    setAddress(newAddress)
+  }, [])
+
+  const handleAmountChange = useCallback((stringAmount: string) => {
     if (stringAmount === '.' || stringAmount.includes('NaN')) {
       setAmount('0.')
       setBalanceAmount(new Balance(0, CurrencyType.networkToken))
@@ -408,7 +417,7 @@ const SendView = ({ scanResult, sendType, hotspot, isSeller }: Props) => {
     setBalanceAmount(
       new Balance(parseFloat(rawAmount) * 100000000, CurrencyType.networkToken),
     )
-  }
+  }, [])
 
   return (
     <Box flex={1}>
@@ -434,7 +443,7 @@ const SendView = ({ scanResult, sendType, hotspot, isSeller }: Props) => {
           fee={fee}
           transferData={transferData}
           lastReportedActivity={lastReportedActivity}
-          onAddressChange={setAddress}
+          onAddressChange={handleAddressChange}
           onAmountChange={handleAmountChange}
           onDcAmountChange={setDcAmount}
           onMemoChange={setMemo}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -427,11 +427,13 @@ export default {
       send: 'Send HNT',
       send_description: 'Quickly scan a Helium address to send HNT.',
       burn: 'Burn HNT to DC',
-      burn_description: 'HNT can be burned into Data Credits to pay for device network connectivity. DCs are non-transferable.',
+      burn_description:
+        'HNT can be burned into Data Credits to pay for device network connectivity. DCs are non-transferable.',
       view: 'View QR Code',
-      view_description: 'Share your QR Code to deposit or receive HNT from others.',
+      view_description:
+        'Share your QR Code to deposit or receive HNT from others.',
       learn_more: 'Learn More',
-    }
+    },
   },
   more: {
     title: 'Settings',

--- a/src/utils/explorerClient.ts
+++ b/src/utils/explorerClient.ts
@@ -1,0 +1,45 @@
+/* eslint-disable import/prefer-default-export */
+import * as Logger from './logger'
+
+const makeRequest = async (url: string, opts: RequestInit) => {
+  Logger.breadcrumb(`request: ${opts.method} ${url}`)
+  try {
+    const route = ['https://explorer.helium.com/api', url].join('/')
+
+    const response = await fetch(route, {
+      ...opts,
+      headers: {
+        ...opts.headers,
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      const error = new Error(
+        `Bad response, status:${response.status} message:${response.statusText}`,
+      )
+      Logger.error(error)
+      throw error
+    }
+
+    const text = await response.text()
+    try {
+      const json = JSON.parse(text)
+      return json.data || json
+    } catch (err) {
+      return text
+    }
+  } catch (error) {
+    Logger.breadcrumb('fetch failed')
+    Logger.error(error)
+    throw error
+  }
+}
+
+export const getExplorer = async (url: string) =>
+  makeRequest(url, {
+    method: 'GET',
+  })
+
+export const ensLookup = async (name: string) => getExplorer(`ens/${name}`)


### PR DESCRIPTION
[ENS](https://ens.domains/) supports HNT, this allows a valid ENS address to be used to send HNT.

Some unrelated code style changes also seem to have gotten picked up by my husky hook.