### PR TITLE
Make security screen full screen.

### DIFF
--- a/src/features/security/SecurityScreen.tsx
+++ b/src/features/security/SecurityScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, memo, useRef, useMemo, useState } from 'react'
 import { Animated, ImageStyle, Image, Platform } from 'react-native'
+import Box from '../../components/Box'
 
 const AnimatedImage = Animated.createAnimatedComponent(Image)
 
@@ -42,8 +43,9 @@ const SecurityScreen = ({ visible }: Props) => {
   const style = useMemo(
     () =>
       ({
-        position: 'absolute',
         opacity: fadeAnim.current,
+        height: '100%',
+        width: '100%',
       } as Animated.AnimatedProps<ImageStyle>),
     [],
   )
@@ -57,10 +59,12 @@ const SecurityScreen = ({ visible }: Props) => {
   }
 
   return (
-    <AnimatedImage
-      style={style}
-      source={require('../../assets/images/SplashScreen.png')}
-    />
+    <Box position="absolute" top={0} left={0} right={0} bottom={0}>
+      <AnimatedImage
+        style={style}
+        source={require('../../assets/images/SplashScreen.png')}
+      />
+    </Box>
   )
 }
 


### PR DESCRIPTION
Closes #234

Security screen wasn't full screen on the iPhone 12 Pro Max. Updated the layout to handle it differently.