### PR TITLE
Fix/misc fixes

### DIFF
--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -136,7 +136,9 @@ const BarChart = ({
   const panResponder = useMemo(
     () =>
       PanResponder.create({
-        onMoveShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: (e, gestureState) => {
+          return Math.abs(gestureState.dy) < 10
+        },
         onPanResponderMove: (evt) => {
           const dataIndex = findDataIndex(evt.nativeEvent.locationX)
           setFocusedBar(data[dataIndex])

--- a/src/features/wallet/root/BalanceCard/BalanceCard.tsx
+++ b/src/features/wallet/root/BalanceCard/BalanceCard.tsx
@@ -83,11 +83,7 @@ const BalanceCard = ({ onReceivePress, onSendPress }: Props) => {
           />
           <CurrencyBadge
             variant="hst"
-            amount={
-              account?.secBalance
-                ? parseFloat(account.secBalance.toString())
-                : 0
-            }
+            amount={account?.secBalance?.floatBalance || 0}
           />
         </Box>
       </Box>

--- a/src/features/wallet/root/BalanceCard/BalanceCard.tsx
+++ b/src/features/wallet/root/BalanceCard/BalanceCard.tsx
@@ -83,7 +83,11 @@ const BalanceCard = ({ onReceivePress, onSendPress }: Props) => {
           />
           <CurrencyBadge
             variant="hst"
-            amount={account?.secBalance?.integerBalance || 0}
+            amount={
+              account?.secBalance
+                ? parseFloat(account.secBalance.toString())
+                : 0
+            }
           />
         </Box>
       </Box>

--- a/src/features/wallet/root/BalanceCard/WalletButton.tsx
+++ b/src/features/wallet/root/BalanceCard/WalletButton.tsx
@@ -31,13 +31,13 @@ const WalletButton = ({ variant, onPress, disabled }: Props) => {
       >
         {variant === 'send' && (
           <Send
-            width={wp(5.5)}
+            height={17.5}
             color={disabled ? colors.purple500 : colors.blueBright}
           />
         )}
         {variant === 'receive' && (
           <Receive
-            width={wp(5.5)}
+            height={17.5}
             color={disabled ? colors.purple500 : colors.greenBright}
           />
         )}


### PR DESCRIPTION
resolves #122 
- sets wallet button icons to use a fixed height rather than width so that the icons will render the same size
- fixes security token amount display

resolves #188 
- tune the chart pan responder to reject gestures that are too vertical, this allows you to swipe down the hotspot charts view without having your gesture stolen by the chart

this isn't 100% perfect, you can still get a chart stuck in an active state if you manage to trigger the scroll gesture while the chart is active. But it doesn't impact the usability because you can still scroll and it's easy to get the chart unstuck. I think we could do something fancy with nested gesture-handlers and `waitFor`, but this is an improvement over the current situation.