### PR TITLE
fetch account chart data when new blocks come in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import NavigationRoot from './navigation/NavigationRoot'
 import { useAppDispatch } from './store/store'
 import appSlice, { restoreUser } from './store/user/appSlice'
 import { RootState } from './store/rootReducer'
-import { fetchData } from './store/account/accountSlice'
+import { fetchActivityChart, fetchData } from './store/account/accountSlice'
 import BluetoothProvider from './providers/BluetoothProvider'
 import ConnectedHotspotProvider from './providers/ConnectedHotspotProvider'
 import * as Logger from './utils/logger'
@@ -67,7 +67,8 @@ const App = () => {
       isLocked,
       appStateStatus,
     },
-    account: { fetchDataStatus },
+    account: { fetchDataStatus, activityChartRange },
+    activity: { filter },
     heliumData: { blockHeight },
   } = useSelector((state: RootState) => state)
 
@@ -105,14 +106,19 @@ const App = () => {
     if (!isRestored) {
       dispatch(restoreUser())
     }
+    // fetch common data
     dispatch(fetchInitialData())
 
     if (!isRestored && !isBackedUp) {
       return
     }
 
+    // fetch account specific data if logged in
     dispatch(fetchData())
-  }, [dispatch, isBackedUp, isRestored])
+    dispatch(
+      fetchActivityChart({ range: activityChartRange, filterType: filter }),
+    )
+  }, [activityChartRange, dispatch, filter, isBackedUp, isRestored])
 
   useEffect(() => {
     loadInitialData()
@@ -161,7 +167,10 @@ const App = () => {
 
   useEffect(() => {
     dispatch(fetchData())
-  }, [blockHeight, dispatch])
+    dispatch(
+      fetchActivityChart({ range: activityChartRange, filterType: filter }),
+    )
+  }, [activityChartRange, blockHeight, dispatch, filter])
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/BarChart/WalletChart.tsx
+++ b/src/components/BarChart/WalletChart.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, TouchableWithoutFeedback } from 'react-native'
-import { round } from 'lodash'
+import { isEqual, round } from 'lodash'
 import { useSelector } from 'react-redux'
 import ChartContainer from './ChartContainer'
 import CarotLeft from '../../assets/images/carot-left.svg'
@@ -26,7 +26,7 @@ const WalletChart = ({ height }: Props) => {
   const {
     account: { activityChart, activityChartRange },
     activity: { filter },
-  } = useSelector((state: RootState) => state)
+  } = useSelector((state: RootState) => state, selectorIsEqual)
 
   const [focusedData, setFocusedData] = useState<ChartData | null>(null)
 
@@ -142,6 +142,18 @@ const WalletChart = ({ height }: Props) => {
       />
     </Box>
   )
+}
+
+const selectorIsEqual = (prev: RootState, next: RootState) => {
+  const activityChartEqual = isEqual(
+    prev.account.activityChart,
+    next.account.activityChart,
+  )
+  const rangeEqual =
+    prev.account.activityChartRange === next.account.activityChartRange
+  const filterEqual = prev.activity.filter === next.activity.filter
+
+  return activityChartEqual && rangeEqual && filterEqual
 }
 
 export default memo(WalletChart)

--- a/src/components/BarChart/WalletChart.tsx
+++ b/src/components/BarChart/WalletChart.tsx
@@ -12,7 +12,9 @@ import { triggerImpact } from '../../utils/haptic'
 import { useColors } from '../../theme/themeHooks'
 import { useAppDispatch } from '../../store/store'
 import { RootState } from '../../store/rootReducer'
-import { fetchActivityChart } from '../../store/account/accountSlice'
+import accountSlice, {
+  fetchActivityChart,
+} from '../../store/account/accountSlice'
 import { locale } from '../../utils/i18n'
 
 type Props = {
@@ -22,21 +24,22 @@ type Props = {
 const WalletChart = ({ height }: Props) => {
   const dispatch = useAppDispatch()
   const {
-    account: { activityChart },
+    account: { activityChart, activityChartRange },
     activity: { filter },
   } = useSelector((state: RootState) => state)
 
   const [focusedData, setFocusedData] = useState<ChartData | null>(null)
-  const [timeframe, setTimeframe] = useState<ChartRange>('daily')
 
-  const data = useMemo(() => activityChart[timeframe].data, [
+  const data = useMemo(() => activityChart[activityChartRange].data, [
     activityChart,
-    timeframe,
+    activityChartRange,
   ])
 
   useEffect(() => {
-    dispatch(fetchActivityChart({ range: timeframe, filterType: filter }))
-  }, [dispatch, timeframe, filter])
+    dispatch(
+      fetchActivityChart({ range: activityChartRange, filterType: filter }),
+    )
+  }, [dispatch, filter, activityChartRange])
 
   const headerHeight = 30
   const padding = 20
@@ -44,10 +47,10 @@ const WalletChart = ({ height }: Props) => {
 
   const changeTimeframe = useCallback(
     (range: ChartRange) => () => {
-      setTimeframe(range)
+      dispatch(accountSlice.actions.setActivityChartRange(range))
       triggerImpact()
     },
-    [],
+    [dispatch],
   )
 
   const handleFocusData = useCallback((chartData: ChartData | null): void => {
@@ -97,17 +100,26 @@ const WalletChart = ({ height }: Props) => {
         </Box>
         <Box flex={1} flexDirection="row" justifyContent="space-between">
           <TouchableWithoutFeedback onPress={changeTimeframe('daily')}>
-            <Text variant="body1" opacity={timeframe === 'daily' ? 1 : 0.3}>
+            <Text
+              variant="body1"
+              opacity={activityChartRange === 'daily' ? 1 : 0.3}
+            >
               14D
             </Text>
           </TouchableWithoutFeedback>
           <TouchableWithoutFeedback onPress={changeTimeframe('weekly')}>
-            <Text variant="body1" opacity={timeframe === 'weekly' ? 1 : 0.3}>
+            <Text
+              variant="body1"
+              opacity={activityChartRange === 'weekly' ? 1 : 0.3}
+            >
               12W
             </Text>
           </TouchableWithoutFeedback>
           <TouchableWithoutFeedback onPress={changeTimeframe('monthly')}>
-            <Text variant="body1" opacity={timeframe === 'monthly' ? 1 : 0.3}>
+            <Text
+              variant="body1"
+              opacity={activityChartRange === 'monthly' ? 1 : 0.3}
+            >
               12M
             </Text>
           </TouchableWithoutFeedback>

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
 import { Account, Hotspot } from '@helium/http'
 import { getHotspots, getAccount } from '../../utils/appDataClient'
 import { getWallet, postWallet } from '../../utils/walletClient'
@@ -37,6 +37,7 @@ export type AccountState = {
   fetchDataStatus: Loading
   markNotificationStatus: Loading
   activityChart: ActivityChart
+  activityChartRange: ChartRange
 }
 
 const initialState: AccountState = {
@@ -49,6 +50,7 @@ const initialState: AccountState = {
     weekly: { data: [], loading: 'idle' },
     monthly: { data: [], loading: 'idle' },
   },
+  activityChartRange: 'daily',
 }
 
 type AccountData = {
@@ -106,6 +108,9 @@ const accountSlice = createSlice({
     },
     resetActivityChart: (state) => {
       return { ...state, activityChart: initialState.activityChart }
+    },
+    setActivityChartRange: (state, action: PayloadAction<ChartRange>) => {
+      return { ...state, activityChartRange: action.payload }
     },
   },
   extraReducers: (builder) => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,6 +14,9 @@ export const setUser = (userAddress: string) => {
 }
 
 export const error = (e: unknown) => {
+  if (__DEV__) {
+    console.error(e)
+  }
   Sentry.captureException(e)
 }
 


### PR DESCRIPTION
Adds chart data to the data that gets fetched on initial load and when new blocks come in. I noticed that the chart data wasn't updating when I was testing pending transactions. This should make it consistent with the timing of the other data we fetch.