### PR TITLE
fix dropdown caret spacing

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -14,10 +14,10 @@ const Dropdown = ({ children, title }: Props) => {
   return (
     <Box>
       <TouchableOpacityBox flexDirection="row" onPress={() => setOpen(!open)}>
-        <Text variant="body1" color="grayBlack">
+        <Text variant="body1" color="grayBlack" marginRight="s">
           {upperCase(title)}
         </Text>
-        <Box height={12} justifyContent="center">
+        <Box height={12} marginTop="xxs" justifyContent="center">
           <ImageBox
             style={
               !open && {


### PR DESCRIPTION
resolves #272 

Now looks like:

![image](https://user-images.githubusercontent.com/792845/108911350-01e56d80-75dc-11eb-9098-c9d68f794e9b.png)
