### PR TITLE
pin for payment

### DIFF
--- a/src/features/lock/LockScreen.tsx
+++ b/src/features/lock/LockScreen.tsx
@@ -21,7 +21,7 @@ type Route = RouteProp<RootStackParamList, 'LockScreen'>
 const LockScreen = () => {
   const { t } = useTranslation()
   const {
-    params: { lock: shouldLock, requestType },
+    params: { lock: shouldLock, requestType, scanResult },
   } = useRoute<Route>()
   const rootNav = useNavigation<RootNavigationProp>()
   const moreNav = useNavigation<MoreNavigationProp>()
@@ -37,13 +37,21 @@ const LockScreen = () => {
         rootNav.goBack()
       })
     } else if (requestType === 'send') {
-      rootNav.navigate('Send')
+      rootNav.navigate('Send', { scanResult })
     } else {
       moreNav.navigate('MoreScreen', {
         pinVerifiedFor: requestType,
       })
     }
-  }, [moreNav, requestType, rootNav, setLocked, shouldLock, dispatch])
+  }, [
+    shouldLock,
+    requestType,
+    setLocked,
+    dispatch,
+    rootNav,
+    scanResult,
+    moreNav,
+  ])
 
   const handleSignOut = useCallback(() => {
     Alert.alert(

--- a/src/features/lock/LockScreen.tsx
+++ b/src/features/lock/LockScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, memo } from 'react'
+import React, { memo, useCallback, useEffect } from 'react'
 import { Alert } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
@@ -36,6 +36,8 @@ const LockScreen = () => {
         dispatch(appSlice.actions.lock(false))
         rootNav.goBack()
       })
+    } else if (requestType === 'send') {
+      rootNav.navigate('Send')
     } else {
       moreNav.navigate('MoreScreen', {
         pinVerifiedFor: requestType,

--- a/src/features/moreTab/more/MoreListItem.tsx
+++ b/src/features/moreTab/more/MoreListItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import { Linking, Switch } from 'react-native'
 import RNPickerSelect, { Item } from 'react-native-picker-select'
 import Text from '../../../components/Text'
@@ -51,6 +51,11 @@ const MoreListItem = ({
     }
   }
 
+  const trackColor = useMemo(
+    () => ({ false: colors.purple400, true: colors.purpleMain }),
+    [colors],
+  )
+
   return (
     <TouchableOpacityBox
       flexDirection="row"
@@ -78,8 +83,8 @@ const MoreListItem = ({
         <Switch
           value={value as boolean}
           onValueChange={onToggle}
-          trackColor={{ false: '#303351', true: colors.purpleMain }}
-          thumbColor="#FFFFFF"
+          trackColor={trackColor}
+          thumbColor={colors.white}
         />
       )}
       {select && (

--- a/src/features/moreTab/more/MoreListItem.tsx
+++ b/src/features/moreTab/more/MoreListItem.tsx
@@ -78,7 +78,8 @@ const MoreListItem = ({
         <Switch
           value={value as boolean}
           onValueChange={onToggle}
-          trackColor={{ false: colors.purpleMain, true: colors.purpleMain }}
+          trackColor={{ false: '#303351', true: colors.purpleMain }}
+          thumbColor="#FFFFFF"
         />
       )}
       {select && (

--- a/src/features/moreTab/more/MoreListItem.tsx
+++ b/src/features/moreTab/more/MoreListItem.tsx
@@ -52,7 +52,7 @@ const MoreListItem = ({
   }
 
   const trackColor = useMemo(
-    () => ({ false: colors.purple400, true: colors.purpleMain }),
+    () => ({ false: colors.purple300, true: colors.purpleMain }),
     [colors],
   )
 

--- a/src/features/wallet/root/WalletViewContainer.tsx
+++ b/src/features/wallet/root/WalletViewContainer.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native'
 import BottomSheet from '@gorhom/bottom-sheet'
 import Qr from '@assets/images/qr.svg'
 import { AnyTransaction, PendingTransaction } from '@helium/http'
+import { useSelector } from 'react-redux'
 import Box from '../../../components/Box'
 import Text from '../../../components/Text'
 import BalanceCard from './BalanceCard/BalanceCard'
@@ -18,6 +19,7 @@ import WalletIntroCarousel from './WalletIntroCarousel'
 import { Loading } from '../../../store/activity/activitySlice'
 import { ActivityViewState, FilterType } from './walletTypes'
 import WalletView from './WalletView'
+import { RootState } from '../../../store/rootReducer'
 
 type Props = {
   layout: WalletLayout
@@ -44,6 +46,9 @@ const WalletViewContainer = ({
 }: Props) => {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const {
+    app: { isPinRequiredForPayment },
+  } = useSelector((state: RootState) => state)
 
   const activityCardRef = useRef<BottomSheet>(null)
   const balanceSheetRef = useRef<BottomSheet>(null)
@@ -58,8 +63,14 @@ const WalletViewContainer = ({
 
   const handleSendPress = useCallback(() => {
     triggerNavHaptic()
-    navigation.navigate('Send')
-  }, [navigation])
+    if (isPinRequiredForPayment) {
+      navigation.navigate('LockScreen', {
+        requestType: 'send',
+      })
+    } else {
+      navigation.navigate('Send')
+    }
+  }, [isPinRequiredForPayment, navigation])
 
   const toggleShowReceive = useCallback(() => {
     if (activityViewState === 'no_activity') {

--- a/src/features/wallet/scan/ScanView.tsx
+++ b/src/features/wallet/scan/ScanView.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner'
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import { Address } from '@helium/crypto-react-native'
+import { useSelector } from 'react-redux'
 import Box from '../../../components/Box'
 import Text from '../../../components/Text'
 import Crosshair from './Crosshair'
@@ -16,6 +17,7 @@ import { triggerNavHaptic, triggerNotification } from '../../../utils/haptic'
 import { QrScanResult, ScanType } from './scanTypes'
 import BSHandle from '../../../components/BSHandle'
 import { useSpacing } from '../../../theme/themeHooks'
+import { RootState } from '../../../store/rootReducer'
 
 type Props = {
   scanType?: ScanType
@@ -26,6 +28,9 @@ const ScanView = ({ scanType = 'payment', showBottomSheet = true }: Props) => {
   const [scanned, setScanned] = useState(false)
   const navigation = useNavigation()
   const spacing = useSpacing()
+  const {
+    app: { isPinRequiredForPayment },
+  } = useSelector((state: RootState) => state)
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
@@ -54,7 +59,14 @@ const ScanView = ({ scanType = 'payment', showBottomSheet = true }: Props) => {
       setScanned(true)
       triggerNotification('success')
 
-      navigation.navigate('Send', { scanResult })
+      if (isPinRequiredForPayment) {
+        navigation.navigate('LockScreen', {
+          requestType: 'send',
+          scanResult,
+        })
+      } else {
+        navigation.navigate('Send', { scanResult })
+      }
     } catch (error) {
       handleFailedScan()
     }

--- a/src/features/wallet/send/SendNavigator.tsx
+++ b/src/features/wallet/send/SendNavigator.tsx
@@ -15,12 +15,13 @@ type Props = {
 }
 const SendNavigator = ({ route }: Props) => {
   const scanResult = route?.params?.scanResult
+  const sendParams = { scanResult }
   return (
     <SendStack.Navigator headerMode="none">
       <SendStack.Screen
         name="Send"
         component={SendScreen}
-        initialParams={{ scanResult }}
+        initialParams={sendParams}
       />
       <SendStack.Screen name="SendScan" component={ScanScreen} />
       <SendStack.Screen name="SendComplete" component={SendCompleteScreen} />

--- a/src/features/wallet/send/SendNavigator.tsx
+++ b/src/features/wallet/send/SendNavigator.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react'
 import { createStackNavigator } from '@react-navigation/stack'
+import { RouteProp } from '@react-navigation/native'
 import SendScreen from './SendScreen'
 import ScanScreen from '../scan/ScanScreen'
 import SendCompleteScreen from './SendCompleteScreen'
+import { RootStackParamList } from '../../../navigation/main/tabTypes'
 
 const SendStack = createStackNavigator()
 
-const SendNavigator = () => {
+type Route = RouteProp<RootStackParamList, 'Send'>
+
+type Props = {
+  route: Route
+}
+const SendNavigator = ({ route }: Props) => {
+  const scanResult = route?.params?.scanResult
   return (
     <SendStack.Navigator headerMode="none">
-      <SendStack.Screen name="Send" component={SendScreen} />
+      <SendStack.Screen
+        name="Send"
+        component={SendScreen}
+        initialParams={{ scanResult }}
+      />
       <SendStack.Screen name="SendScan" component={ScanScreen} />
       <SendStack.Screen name="SendComplete" component={SendCompleteScreen} />
     </SendStack.Navigator>

--- a/src/navigation/main/tabTypes.ts
+++ b/src/navigation/main/tabTypes.ts
@@ -1,4 +1,5 @@
 import { StackNavigationProp } from '@react-navigation/stack'
+import { QrScanResult } from '../../features/wallet/scan/scanTypes'
 
 export type MainTabType = 'Hotspots' | 'Wallet' | 'Notifications' | 'More'
 
@@ -19,10 +20,16 @@ export type LockScreenRequestType =
 
 export type RootStackParamList = {
   MainTabs: undefined | { pinVerifiedFor: LockScreenRequestType }
-  LockScreen: { requestType: LockScreenRequestType; lock?: boolean }
+  LockScreen: {
+    requestType: LockScreenRequestType
+    lock?: boolean
+    scanResult?: QrScanResult
+  }
   HotspotSetup: undefined
   Scan: undefined
-  Send: undefined
+  Send: {
+    scanResult?: QrScanResult
+  }
 }
 
 export type RootNavigationProp = StackNavigationProp<RootStackParamList>

--- a/src/navigation/main/tabTypes.ts
+++ b/src/navigation/main/tabTypes.ts
@@ -15,6 +15,7 @@ export type LockScreenRequestType =
   | 'resetPin'
   | 'unlock'
   | 'revealWords'
+  | 'send'
 
 export type RootStackParamList = {
   MainTabs: undefined | { pinVerifiedFor: LockScreenRequestType }


### PR DESCRIPTION
closes #302 

- Fixes require pin for payments
- Require pin when navigating to send screen from wallet
- Require pin when navigating to send from payment QR 
- Updates the Android toggle colors in settings to match iOS

![Screen Shot 2021-02-25 at 5 05 22 PM](https://user-images.githubusercontent.com/6345962/109242944-e079b280-7790-11eb-8d86-d876b75927c1.png)
