### PR TITLE
add onboarding error screen to hotspot setup flow

### DIFF
--- a/src/components/EmojiBlip.tsx
+++ b/src/components/EmojiBlip.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useCallback, useMemo } from 'react'
 import Blip from '@assets/images/blip.svg'
 import Emoji from 'react-native-emoji'
 import { sample } from 'lodash'
@@ -21,21 +21,30 @@ const emojis = {
   ],
 }
 
-const EmojiBlip = ({ date }: { date: Date }) => {
-  const emojiOptions = [...emojis.anytime]
-  const hour = date.getHours()
+const EmojiBlip = ({ date, name }: { date?: Date; name?: string }) => {
+  const pickEmoji = useCallback(() => {
+    if (!date) return '100'
 
-  if (hour >= 4 && hour < 12) {
-    emojiOptions.push(...emojis.morning)
-  }
-  if (hour >= 12 && hour < 15) {
-    emojiOptions.push(...emojis.lunch)
-  }
-  if (hour >= 18 || hour < 4) {
-    emojiOptions.push(...emojis.evening)
-  }
+    const emojiOptions = [...emojis.anytime]
+    const hour = date.getHours()
 
-  const emojiName = sample(emojiOptions) || '100'
+    if (hour >= 4 && hour < 12) {
+      emojiOptions.push(...emojis.morning)
+    }
+    if (hour >= 12 && hour < 15) {
+      emojiOptions.push(...emojis.lunch)
+    }
+    if (hour >= 18 || hour < 4) {
+      emojiOptions.push(...emojis.evening)
+    }
+
+    return sample(emojiOptions)
+  }, [date])
+
+  const emojiName = useMemo(() => name || pickEmoji() || '100', [
+    name,
+    pickEmoji,
+  ])
 
   return (
     <Box width={70} marginBottom="m">

--- a/src/features/hotspots/setup/HotspotSetupConfirmLocationScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupConfirmLocationScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { ActivityIndicator } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
@@ -16,6 +16,7 @@ import Map from '../../../components/Map'
 import Text from '../../../components/Text'
 import { useConnectedHotspotContext } from '../../../providers/ConnectedHotspotProvider'
 import { RootState } from '../../../store/rootReducer'
+import * as Logger from '../../../utils/logger'
 import { decimalSeparator, groupSeparator } from '../../../utils/i18n'
 
 type Route = RouteProp<
@@ -30,15 +31,22 @@ const HotspotSetupConfirmLocationScreen = () => {
   const {
     account: { account },
   } = useSelector((state: RootState) => state)
-  const { loading, result } = useAsync(loadLocationFeeData, [])
+  const { loading, result, error } = useAsync(loadLocationFeeData, [])
 
   const {
     params: { hotspotCoords, locationName },
   } = useRoute<Route>()
 
-  const navNext = async () => {
+  useEffect(() => {
+    if (error) {
+      Logger.error(error)
+      navigation.navigate('OnboardingErrorScreen')
+    }
+  }, [error, navigation])
+
+  const navNext = useCallback(async () => {
     navigation.replace('HotspotTxnsProgressScreen', { hotspotCoords })
-  }
+  }, [hotspotCoords, navigation])
 
   if (loading || !result) {
     return (

--- a/src/features/hotspots/setup/HotspotSetupConnectingScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupConnectingScreen.tsx
@@ -2,7 +2,6 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
 import { uniq } from 'lodash'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert } from 'react-native'
 import Box from '../../../components/Box'
 import RadarLoader from '../../../components/Loaders/RadarLoader'
 import SafeAreaBox from '../../../components/SafeAreaBox'
@@ -40,9 +39,7 @@ const HotspotSetupConnectingScreen = () => {
 
       // check for valid onboarding record
       if (!success) {
-        // TODO actual screen for this
-        Alert.alert('Error', 'Invalid onboarding record')
-        navigation.goBack()
+        navigation.navigate('OnboardingErrorScreen')
         return
       }
 

--- a/src/features/hotspots/setup/HotspotSetupNavigator.tsx
+++ b/src/features/hotspots/setup/HotspotSetupNavigator.tsx
@@ -17,6 +17,7 @@ import HotspotTxnsProgressScreen from './HotspotTxnsProgressScreen'
 import HotspotSetupWifiConnectingScreen from './HotspotSetupWifiConnectingScreen'
 import HotspotSetupConfirmLocationScreen from './HotspotSetupConfirmLocationScreen'
 import HotspotSetupPickWifiScreen from './HotspotSetupPickWifiScreen'
+import OnboardingErrorScreen from './OnboardingErrorScreen'
 
 const HotspotSetupStack = createStackNavigator()
 
@@ -57,6 +58,10 @@ const HotspotSetup = () => {
       <HotspotSetupStack.Screen
         name="HotspotSetupConnectingScreen"
         component={HotspotSetupConnectingScreen}
+      />
+      <HotspotSetupStack.Screen
+        name="OnboardingErrorScreen"
+        component={OnboardingErrorScreen}
       />
       <HotspotSetupStack.Screen
         name="HotspotSetupPickWifiScreen"

--- a/src/features/hotspots/setup/OnboardingErrorScreen.tsx
+++ b/src/features/hotspots/setup/OnboardingErrorScreen.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback } from 'react'
+import { useNavigation } from '@react-navigation/native'
+import { useTranslation } from 'react-i18next'
+import Box from '../../../components/Box'
+import Button from '../../../components/Button'
+import EmojiBlip from '../../../components/EmojiBlip'
+import SafeAreaBox from '../../../components/SafeAreaBox'
+import Text from '../../../components/Text'
+import { RootNavigationProp } from '../../../navigation/main/tabTypes'
+
+const OnboardingErrorScreen = () => {
+  const { t } = useTranslation()
+  const navigation = useNavigation<RootNavigationProp>()
+
+  const navNext = useCallback(() => {
+    navigation.navigate('MainTabs')
+  }, [navigation])
+
+  return (
+    <SafeAreaBox backgroundColor="primaryBackground" flex={1} padding="l">
+      <Box flex={1} justifyContent="center" paddingBottom="xxl">
+        <Box paddingBottom="l">
+          <EmojiBlip name="exploding_head" />
+        </Box>
+
+        <Text variant="h1">{t('hotspot_setup.onboarding_error.title')}</Text>
+        <Text variant="body1" marginVertical="l">
+          {t('hotspot_setup.onboarding_error.subtitle')}
+        </Text>
+      </Box>
+      <Box>
+        <Button
+          mode="contained"
+          variant="primary"
+          title={t('hotspot_setup.onboarding_error.next')}
+          onPress={navNext}
+        />
+      </Box>
+    </SafeAreaBox>
+  )
+}
+
+export default OnboardingErrorScreen

--- a/src/features/hotspots/setup/hotspotSetupTypes.tsx
+++ b/src/features/hotspots/setup/hotspotSetupTypes.tsx
@@ -10,6 +10,7 @@ export type HotspotSetupStackParamList = {
   HotspotSetupScanningScreen: { hotspotType: HotspotType }
   HotspotSetupPickHotspotScreen: { hotspotType: HotspotType }
   HotspotSetupConnectingScreen: { hotspotId: string }
+  OnboardingErrorScreen: undefined
   HotspotSetupPickWifiScreen: {
     networks: string[]
     connectedNetworks: string[]

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -318,6 +318,12 @@ export default {
         'Your Hotspot will check for updates automatically. This can take about 10 minutes. Leave it plugged in and check back later.',
       next: 'Got it',
     },
+    onboarding_error: {
+      title: 'Onboarding Error',
+      subtitle:
+        'Unable to find Hotspot in the Onboarding Server. Please contact the Hotspot manufacturer for next steps.',
+      next: 'Exit Setup',
+    },
     add_hotspot: {
       title: 'Add Hotspot',
       subtitle:

--- a/src/utils/useHotspot.ts
+++ b/src/utils/useHotspot.ts
@@ -28,6 +28,7 @@ import { getSecureItem } from './secureAccount'
 import { makeAddGatewayTxn, makeAssertLocTxn } from './transactions'
 import { calculateAddGatewayFee, calculateAssertLocFee } from './fees'
 import connectedHotspotSlice, {
+  AllHotspotDetails,
   fetchHotspotDetails,
   HotspotName,
   HotspotStatus,
@@ -184,6 +185,11 @@ const useHotspot = () => {
     }
 
     const response = await dispatch(fetchHotspotDetails(details))
+    if (
+      !(response.payload as AllHotspotDetails).onboardingRecord?.onboardingKey
+    ) {
+      return false
+    }
     return !!response.payload
   }
 


### PR DESCRIPTION
at one point we were throwing an alert error when onboarding record couldn't be found. The logic to trigger this alert changed and it was no longer getting triggered, leading the user to get further along in the setup than they should have. This adds a proper screen for onboarding error, and navigates to it when there is no onboarding record.

resolves: #307 