### PR TITLE
open hotspot details expanded & improve map navigation

### DIFF
--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -151,7 +151,11 @@ const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
                 hotspot?.status?.online || hotspotDetailsHotspot?.status?.online
               }
             />
-            <HexBadge rewardScale={hotspot.rewardScale} />
+            <HexBadge
+              rewardScale={
+                hotspot.rewardScale || hotspotDetailsHotspot?.rewardScale
+              }
+            />
           </Box>
           <Address
             address={hotspot.owner}

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -48,6 +48,7 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
   const colors = useColors()
 
   const [listIsDismissed, setListIsDismissed] = useState(false)
+  const [detailsSnapIndex, setDetailsSnapIndex] = useState(1)
 
   const listRef = useRef<BottomSheetModal>(null)
   const detailsRef = useRef<BottomSheetModal>(null)
@@ -91,17 +92,20 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
 
   const handleDismissList = useCallback(() => {
     setSelectedHotspot(ownedHotspots[0])
+    setDetailsSnapIndex(0)
     detailsRef.current?.present()
     setListIsDismissed(true)
   }, [ownedHotspots])
 
   const handlePressMyHotspots = useCallback(() => {
     setSelectedHotspot(ownedHotspots[0])
+    setDetailsSnapIndex(1)
     detailsRef.current?.present()
   }, [ownedHotspots])
 
   const handleDismissDetails = useCallback(() => {
     setSelectedHotspot(undefined)
+    setDetailsSnapIndex(1)
     dispatch(hotspotDetailsSlice.actions.clearHotspotDetails())
     if (listIsDismissed) {
       listRef.current?.present()
@@ -213,8 +217,9 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
           zoomLevel={14}
           mapCenter={mapCenter}
           witnesses={showWitnesses ? witnesses : []}
-          animationMode="moveTo"
-          offsetCenterRatio={2.0}
+          animationMode="easeTo"
+          animationDuration={500}
+          offsetCenterRatio={2.2}
           onFeatureSelected={onMapHotspotSelected}
           interactive={hasLocation}
           showNoLocation={!hasLocation}
@@ -295,7 +300,7 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
       <BottomSheetModal
         ref={detailsRef}
         snapPoints={detailSnapPoints}
-        index={0}
+        index={detailsSnapIndex}
         handleComponent={BSHandle}
         onDismiss={handleDismissDetails}
         animatedIndex={animatedDetailsPosition}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,9 +21,6 @@ export const error = (e: unknown) => {
 }
 
 export const breadcrumb = (message: string) => {
-  if (__DEV__) {
-    console.log(message)
-  }
   Sentry.addBreadcrumb({
     message,
   })


### PR DESCRIPTION
closes #251 

- Open details in expanded mode by default
- Swiping the list down still opens the details minimized
- Fixes reward scaling now showing on network hotspots
- Improves animation when jumping between hotspots


https://user-images.githubusercontent.com/6345962/109373875-60258100-7866-11eb-8a26-ce67a65c8761.mov

