### PR TITLE
move settings to hotspot header

### DIFF
--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import animalName from 'angry-purple-tiger'
 import { useTranslation } from 'react-i18next'
@@ -12,39 +12,31 @@ import HotspotDetailChart from './HotspotDetailChart'
 import { RootState } from '../../../store/rootReducer'
 import { getRewardChartData } from './RewardsHelper'
 import { useAppDispatch } from '../../../store/store'
-import hotspotDetailsSlice, {
-  fetchHotspotDetails,
-} from '../../../store/hotspotDetails/hotspotDetailsSlice'
-import HotspotSettingsProvider from '../settings/HotspotSettingsProvider'
-import HotspotSettings from '../settings/HotspotSettings'
+import { fetchHotspotDetails } from '../../../store/hotspotDetails/hotspotDetailsSlice'
 import HexBadge from './HexBadge'
 import HotspotMoreMenuButton from './HotspotMoreMenuButton'
-import Button from '../../../components/Button'
 import HotspotChecklist from '../checklist/HotspotChecklist'
 import Address from '../../../components/Address'
 
 const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-
   const {
-    account: { account },
-    hotspotDetails: {
-      hotspot: hotspotDetailsHotspot,
-      numDays,
-      rewards,
-      rewardSum,
-      rewardsChange,
-      loading,
-      witnessSums,
-      witnessAverage,
-      witnessChange,
-      challengeSums,
-      challengeSum,
-      challengeChange,
-      witnesses,
-    },
-  } = useSelector((state: RootState) => state)
+    hotspot: hotspotDetailsHotspot,
+    numDays,
+    rewards,
+    rewardSum,
+    rewardsChange,
+    loading,
+    witnessSums,
+    witnessAverage,
+    witnessChange,
+    challengeSums,
+    challengeSum,
+    challengeChange,
+    witnesses,
+  } = useSelector((state: RootState) => state.hotspotDetails)
+  const { account } = useSelector((state: RootState) => state.account)
 
   const [timelineValue, setTimelineValue] = useState(14)
 
@@ -55,10 +47,6 @@ const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
       fetchHotspotDetails({ address: hotspot.address, numDays: timelineValue }),
     )
   }, [dispatch, hotspot, timelineValue])
-
-  const handleToggleSettings = useCallback(() => {
-    dispatch(hotspotDetailsSlice.actions.toggleShowSettings())
-  }, [dispatch])
 
   const witnessChartData = useMemo(() => {
     let options: Intl.DateTimeFormatOptions
@@ -133,10 +121,7 @@ const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
           >
             {animalName(hotspot.address)}
           </Text>
-
-          {hotspot.owner === account?.address && (
-            <HotspotMoreMenuButton hotspot={hotspot} />
-          )}
+          <HotspotMoreMenuButton hotspot={hotspot} />
         </Box>
         <Box
           flexDirection="row"
@@ -196,21 +181,7 @@ const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
           data={challengeChartData}
           loading={loading}
         />
-
-        {hotspot.owner === account?.address && (
-          <Box marginTop="m" paddingHorizontal="l">
-            <Button
-              mode="contained"
-              variant="primary"
-              title="Settings"
-              onPress={handleToggleSettings}
-            />
-          </Box>
-        )}
       </Box>
-      <HotspotSettingsProvider>
-        <HotspotSettings hotspot={hotspot} />
-      </HotspotSettingsProvider>
     </BottomSheetScrollView>
   )
 }

--- a/src/features/hotspots/details/HotspotMoreMenuButton.tsx
+++ b/src/features/hotspots/details/HotspotMoreMenuButton.tsx
@@ -5,13 +5,10 @@ import { useActionSheet } from '@expo/react-native-action-sheet'
 import { useTranslation } from 'react-i18next'
 import MoreMenu from '@assets/images/moreMenu.svg'
 import TouchableOpacityBox from '../../../components/TouchableOpacityBox'
-import { useAppDispatch } from '../../../store/store'
-import hotspotDetailsSlice from '../../../store/hotspotDetails/hotspotDetailsSlice'
 import { EXPLORER_BASE_URL } from '../../../utils/config'
 
 const HotspotMoreMenuButton = ({ hotspot }: { hotspot: Hotspot }) => {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const { showActionSheetWithOptions } = useActionSheet()
 
   type SettingsOption = { label: string; action?: () => void }
@@ -21,11 +18,6 @@ const HotspotMoreMenuButton = ({ hotspot }: { hotspot: Hotspot }) => {
 
     const explorerUrl = `${EXPLORER_BASE_URL}/hotspots/${hotspot.address}`
     const opts: SettingsOption[] = [
-      {
-        label: t('hotspot_details.options.settings'),
-        action: () =>
-          dispatch(hotspotDetailsSlice.actions.toggleShowSettings()),
-      },
       {
         label: t('hotspot_details.options.viewExplorer'),
         action: () => Linking.openURL(explorerUrl),
@@ -48,7 +40,7 @@ const HotspotMoreMenuButton = ({ hotspot }: { hotspot: Hotspot }) => {
         opts[buttonIndex].action?.()
       },
     )
-  }, [dispatch, hotspot, showActionSheetWithOptions, t])
+  }, [hotspot, showActionSheetWithOptions, t])
 
   return (
     <TouchableOpacityBox

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -20,10 +20,12 @@ import {
 import { useNavigation } from '@react-navigation/native'
 import { GeoJsonProperties } from 'geojson'
 import HotspotIcon from '@assets/images/hotspot-icon-white.svg'
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
 import Text from '../../../components/Text'
 import Box from '../../../components/Box'
 import TouchableOpacityBox from '../../../components/TouchableOpacityBox'
 import Add from '../../../assets/images/add.svg'
+import Settings from '../../../assets/images/settings.svg'
 import Map from '../../../components/Map'
 import { RootState } from '../../../store/rootReducer'
 import hotspotDetailsSlice from '../../../store/hotspotDetails/hotspotDetailsSlice'
@@ -36,6 +38,9 @@ import HotspotDetails from '../details/HotspotDetails'
 import { ReAnimatedBox } from '../../../components/AnimatedBox'
 import { useColors } from '../../../theme/themeHooks'
 import BackButton from '../../../components/BackButton'
+import HotspotSettingsProvider from '../settings/HotspotSettingsProvider'
+import HotspotSettings from '../settings/HotspotSettings'
+import { RootStackParamList } from '../../../navigation/main/tabTypes'
 
 type Props = {
   ownedHotspots: Hotspot[]
@@ -67,18 +72,16 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
 
   const [showWitnesses, toggleShowWitnesses] = useToggle(false)
 
-  const {
-    hotspotDetails: { witnesses, loading },
-  } = useSelector((state: RootState) => state)
+  const { witnesses, loading } = useSelector(
+    (state: RootState) => state.hotspotDetails,
+  )
 
   const [selectedHotspot, setSelectedHotspot] = useState<Hotspot>()
 
   useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', () => {
+    return navigation.addListener('focus', () => {
       dispatch(fetchHotspotsData())
     })
-
-    return unsubscribe
   }, [navigation, dispatch])
 
   const handleLayoutList = useCallback((event: LayoutChangeEvent) => {
@@ -120,16 +123,14 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
   }, [dispatch])
 
   useEffect(() => {
-    const navParent = navigation.dangerouslyGetParent()
+    const navParent = navigation.dangerouslyGetParent() as BottomTabNavigationProp<RootStackParamList>
     if (!navParent) return
 
-    const unsubscribe = navParent.addListener('tabPress', () => {
+    return navParent.addListener('tabPress', () => {
       if (navigation.isFocused()) {
         handleBack()
       }
     })
-
-    return unsubscribe
   }, [handleBack, navigation])
 
   const onMapHotspotSelected = useCallback((properties: GeoJsonProperties) => {
@@ -198,6 +199,10 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
         : [ownedHotspots[0].lng || 0, ownedHotspots[0].lat || 0],
     [selectedHotspot, ownedHotspots],
   )
+
+  const toggleSettings = useCallback(() => {
+    dispatch(hotspotDetailsSlice.actions.toggleShowSettings())
+  }, [dispatch])
 
   return (
     <Box flex={1} flexDirection="column" justifyContent="space-between">
@@ -271,13 +276,9 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
         )}
 
         <Box flexDirection="row" justifyContent="space-between">
-          {/* <TouchableOpacityBox
-            onPress={handleToggleSettings}
-            padding="s"
-            marginRight="s"
-          >
+          <TouchableOpacityBox onPress={toggleSettings} padding="s">
             <Settings width={22} height={22} color="white" />
-          </TouchableOpacityBox> */}
+          </TouchableOpacityBox>
           <TouchableOpacityBox
             onPress={() => navigation.navigate('HotspotSetup')}
             padding="s"
@@ -309,6 +310,10 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
       >
         <HotspotDetails hotspot={selectedHotspot} />
       </BottomSheetModal>
+
+      <HotspotSettingsProvider>
+        <HotspotSettings hotspot={selectedHotspot} />
+      </HotspotSettingsProvider>
     </Box>
   )
 }

--- a/src/features/hotspots/settings/HotspotSettings.tsx
+++ b/src/features/hotspots/settings/HotspotSettings.tsx
@@ -1,17 +1,17 @@
 import React, {
-  useEffect,
   memo,
+  useCallback,
+  useEffect,
+  useMemo,
   useRef,
   useState,
-  useCallback,
-  useMemo,
 } from 'react'
 import {
-  Modal,
+  Alert,
   Animated,
   Easing,
   KeyboardAvoidingView,
-  Alert,
+  Modal,
 } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -44,7 +44,11 @@ import animateTransition from '../../../utils/animateTransition'
 
 type State = 'init' | 'scan' | 'transfer'
 
-const HotspotSettings = ({ hotspot }: { hotspot: Hotspot }) => {
+type Props = {
+  hotspot?: Hotspot
+}
+
+const HotspotSettings = ({ hotspot }: Props) => {
   const { t } = useTranslation()
   const [settingsState, setSettingsState] = useState<State>('init')
   const [title, setTitle] = useState<string>(t('hotspot_settings.title'))
@@ -54,9 +58,10 @@ const HotspotSettings = ({ hotspot }: { hotspot: Hotspot }) => {
   const dispatch = useAppDispatch()
   const { showBack, goBack, disableBack } = useHotspotSettingsContext()
 
-  const {
-    hotspotDetails: { showSettings },
-  } = useSelector((state: RootState) => state)
+  const { account } = useSelector((state: RootState) => state.account)
+  const { showSettings } = useSelector(
+    (state: RootState) => state.hotspotDetails,
+  )
 
   useEffect(() => {
     Animated.timing(slideUpAnimRef.current, {
@@ -192,6 +197,9 @@ const HotspotSettings = ({ hotspot }: { hotspot: Hotspot }) => {
   }, [settingsState, startScan, t, updateTitle])
 
   const secondCard = useMemo(() => {
+    const isOwned = hotspot && hotspot.owner === account?.address
+    if (!hotspot || !isOwned) return null
+
     if (settingsState === 'transfer') {
       return (
         <HotspotTransfer
@@ -213,6 +221,7 @@ const HotspotSettings = ({ hotspot }: { hotspot: Hotspot }) => {
       />
     )
   }, [
+    account?.address,
     handleClose,
     hasActiveTransfer,
     hotspot,
@@ -222,8 +231,6 @@ const HotspotSettings = ({ hotspot }: { hotspot: Hotspot }) => {
     t,
     transferButtonTitle,
   ])
-
-  if (!hotspot) return null
 
   return (
     <Modal


### PR DESCRIPTION
closes #259 

- Settings is now in the top header, this also allows access from the hotspots list.
- Transfer hotspot will only show for owned hotspots.

![Simulator Screen Shot - iPhone 11 - 2021-03-04 at 23 18 56](https://user-images.githubusercontent.com/6345962/110080998-1e9e4580-7d40-11eb-95b1-4a23a21664a3.png)
