### PR TITLE
Add alternative characteristic for Firmware / Software Version

### DIFF
--- a/src/utils/bluetooth/bluetoothDataParser.ts
+++ b/src/utils/bluetooth/bluetoothDataParser.ts
@@ -52,7 +52,8 @@ export function parseChar(
     | typeof HotspotCharacteristic.WIFI_REMOVE
     | typeof HotspotCharacteristic.WIFI_CONNECT_UUID
     | typeof HotspotCharacteristic.ADD_GATEWAY_UUID
-    | typeof FirmwareCharacteristic.FIRMWAREVERSION_UUID,
+    | typeof FirmwareCharacteristic.FIRMWAREVERSION_UUID
+    | typeof HotspotCharacteristic.SOFTWARE_VERSION_UUID,
 ): string
 export function parseChar(
   characteristicValue: string,

--- a/src/utils/bluetooth/bluetoothTypes.ts
+++ b/src/utils/bluetooth/bluetoothTypes.ts
@@ -18,4 +18,5 @@ export enum HotspotCharacteristic {
   ASSERT_LOC_UUID = 'd435f5de-01a4-4e7d-84ba-dfd347f60275',
   DIAGNOSTIC_UUID = 'b833d34f-d871-422c-bf9e-8e6ec117d57e',
   ETHERNET_ONLINE_UUID = 'e5866bd6-0288-4476-98ca-ef7da6b4d289',
+  SOFTWARE_VERSION_UUID = 'c0b64050-697d-463a-a33f-70c4825731f8',
 }

--- a/src/utils/useHotspot.ts
+++ b/src/utils/useHotspot.ts
@@ -312,9 +312,23 @@ const useHotspot = () => {
       connectedHotspot.current,
       Service.FIRMWARESERVICE_UUID,
     )
-    if (!charVal) return false
 
-    const deviceFirmwareVersion = parseChar(charVal, characteristic)
+    const characteristicAlt = HotspotCharacteristic.SOFTWARE_VERSION_UUID
+    const charValAlt = await findAndReadCharacteristic(
+      characteristicAlt,
+      connectedHotspot.current,
+      Service.MAIN_UUID,
+    )
+
+    if (!charVal && !charValAlt) return false
+
+    let deviceFirmwareVersion
+
+    if (charVal) {
+      deviceFirmwareVersion = parseChar(charVal, characteristic)
+    } else if (charValAlt) {
+      deviceFirmwareVersion = parseChar(charValAlt, characteristicAlt)
+    }
 
     const firmware: { version: string } = await getStaking('firmware')
     const { version: minVersion } = firmware


### PR DESCRIPTION
Following up from the issue I created at https://github.com/helium/hotspot-app/issues/354 

I implemented a solution for an alternative characteristic (called Software Version) that is called at the time it checks for firmware.

If the original firmware characteristic is returned it uses that. If that isn't returned it uses the new characteristic as a fallback. And if neither are returned it fails like it should as before.

By implementing it in this way, hotspots that are able to use the old method still work as intended (which I've tested).

And as in our case we can't no longer use this service to provide the characteristic, the new one is in the same custom service which is working perfectly fine.

closes #354 