### PR TITLE
enable accounts without hotspots to view hotspots around them

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import Text from './Text'
 import { Colors, Spacing, Theme } from '../theme/theme'
 import BackArrow from '../assets/images/backArrow.svg'
-import TouchableOpacityBox from './TouchableOpacityBox'
+import { DebouncedTouchableOpacityBox } from './TouchableOpacityBox'
 import { useColors } from '../theme/themeHooks'
 
 type Props = BoxProps<Theme> & {
@@ -27,7 +27,7 @@ const BackButton = ({
   const colors = useColors()
 
   return (
-    <TouchableOpacityBox
+    <DebouncedTouchableOpacityBox
       onPress={onPress}
       alignSelf="flex-start"
       paddingVertical="s"
@@ -46,7 +46,7 @@ const BackButton = ({
       >
         {t('back')}
       </Text>
-    </TouchableOpacityBox>
+    </DebouncedTouchableOpacityBox>
   )
 }
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -33,6 +33,47 @@ import { fetchNetworkHotspots } from '../store/networkHotspots/networkHotspotsSl
 
 const styleURL = 'mapbox://styles/petermain/ckjtsfkfj0nay19o3f9jhft6v'
 
+type LatLng = {
+  lat: number
+  lng: number
+}
+
+type MapBounds = {
+  ne: number[]
+  sw: number[]
+  paddingLeft?: number
+  paddingRight?: number
+  paddingTop?: number
+  paddingBottom?: number
+}
+
+const findBounds = (coords: LatLng[]): MapBounds | undefined => {
+  if (coords.length === 0) {
+    return undefined
+  }
+
+  let minLon = coords[0].lng
+  let maxLon = coords[0].lng
+  let minLat = coords[0].lat
+  let maxLat = coords[0].lat
+
+  coords.forEach((m) => {
+    if (m.lng < minLon) minLon = m.lng
+    if (m.lng > maxLon) maxLon = m.lng
+    if (m.lat < minLat) minLat = m.lat
+    if (m.lat > maxLat) maxLat = m.lat
+  })
+
+  return {
+    ne: [maxLon, maxLat],
+    sw: [minLon, minLat],
+    paddingBottom: 250,
+    paddingLeft: 30,
+    paddingRight: 30,
+    paddingTop: 30,
+  }
+}
+
 type Props = BoxProps<Theme> & {
   onMapMoved?: (coords?: Position) => void
   onDidFinishLoadingMap?: (latitude: number, longitude: number) => void
@@ -43,11 +84,10 @@ type Props = BoxProps<Theme> & {
   zoomLevel?: number
   mapCenter?: number[]
   ownedHotspots?: Hotspot[]
-  selectedHotspots?: Hotspot[]
+  selectedHotspot?: Hotspot
   witnesses?: Hotspot[]
   animationMode?: 'flyTo' | 'easeTo' | 'moveTo'
   animationDuration?: number
-  offsetCenterRatio?: number
   maxZoomLevel?: number
   minZoomLevel?: number
   interactive?: boolean
@@ -61,13 +101,12 @@ const Map = ({
   onMapMoving,
   currentLocationEnabled,
   zoomLevel,
-  mapCenter = [0, 0],
+  mapCenter,
   animationMode = 'moveTo',
   animationDuration = 500,
   ownedHotspots = [],
-  selectedHotspots = [],
+  selectedHotspot,
   witnesses = [],
-  offsetCenterRatio,
   showUserLocation,
   maxZoomLevel = 16,
   minZoomLevel = 0,
@@ -84,7 +123,6 @@ const Map = ({
   const camera = useRef<MapboxGL.Camera>(null)
   const [loaded, setLoaded] = useState(false)
   const [userCoords, setUserCoords] = useState({ latitude: 0, longitude: 0 })
-  const [centerOffset, setCenterOffset] = useState(0)
   const styles = useMemo(() => makeStyles(colors), [colors])
 
   const networkHotspots = useSelector(
@@ -120,10 +158,10 @@ const Map = ({
         ? [userCoords.longitude, userCoords.latitude]
         : [-98.35, 15],
       zoomLevel: userCoords ? 16 : 2,
-      animationDuration: 500,
+      animationDuration,
       heading: 0,
     })
-  }, [userCoords])
+  }, [animationDuration, userCoords])
 
   const handleUserLocationUpdate = useCallback(
     (loc) => {
@@ -164,32 +202,8 @@ const Map = ({
     if (loaded && userCoords) {
       onDidFinishLoadingMap?.(userCoords.latitude, userCoords.longitude)
     }
-    const calculateOffset = async () => {
-      const bounds = await map?.current?.getVisibleBounds()
-      const center = await map?.current?.getCenter()
-      if (bounds && center) {
-        const topLat = bounds[0][1]
-        const centerLat = center[1]
-        const scale = offsetCenterRatio || 1
-        setCenterOffset((topLat - centerLat) / scale)
-      }
-    }
-    if (offsetCenterRatio) {
-      setTimeout(calculateOffset, animationDuration)
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userCoords, loaded, offsetCenterRatio])
-
-  useEffect(() => {
-    const setWitnessZoomLevel = async () => {
-      const hasWitnesses = witnesses ? witnesses.length > 0 : false
-      const zoom = await map?.current?.getZoom()
-      if (hasWitnesses && zoom && zoom > 12) {
-        camera?.current?.zoomTo(12, animationDuration)
-      }
-    }
-    setWitnessZoomLevel()
-  }, [witnesses, animationDuration])
+  }, [userCoords, loaded])
 
   const ownedHotspotFeatures = useMemo(
     () => hotspotsToFeatures(ownedHotspots),
@@ -197,8 +211,8 @@ const Map = ({
   )
 
   const selectedHotspotFeatures = useMemo(
-    () => hotspotsToFeatures(selectedHotspots),
-    [selectedHotspots],
+    () => (selectedHotspot ? hotspotsToFeatures([selectedHotspot]) : []),
+    [selectedHotspot],
   )
 
   const witnessFeatures = useMemo(() => hotspotsToFeatures(witnesses), [
@@ -247,6 +261,27 @@ const Map = ({
       networkHotspotFeatures,
     ],
   )
+
+  const bounds = useMemo(() => {
+    const boundsLocations: LatLng[] = []
+
+    if (mapCenter && !selectedHotspot) {
+      boundsLocations.push({ lng: mapCenter[0], lat: mapCenter[1] })
+    }
+
+    if (selectedHotspot && selectedHotspot.lat && selectedHotspot.lng) {
+      boundsLocations.push({
+        lng: selectedHotspot.lng,
+        lat: selectedHotspot.lat,
+      })
+    }
+
+    witnesses.forEach((w) => {
+      if (w.lat && w.lng) boundsLocations.push({ lng: w.lng, lat: w.lat })
+    })
+
+    return findBounds(boundsLocations)
+  }, [mapCenter, selectedHotspot, witnesses])
 
   const defaultCameraSettings = {
     zoomLevel,
@@ -302,9 +337,9 @@ const Map = ({
           maxZoomLevel={maxZoomLevel}
           minZoomLevel={minZoomLevel}
           defaultSettings={defaultCameraSettings}
+          bounds={bounds}
           animationMode={animationMode}
           animationDuration={animationDuration}
-          centerCoordinate={[mapCenter[0], mapCenter[1] - centerOffset]}
         />
         <MapboxGL.Images images={mapImages} />
         <MapboxGL.ShapeSource
@@ -398,14 +433,14 @@ export default memo(Map, (prevProps, nextProps) => {
   const {
     mapCenter: prevMapCenter,
     ownedHotspots: prevOwnedHotspots,
-    selectedHotspots: prevSelectedHotspots,
+    selectedHotspot: prevSelectedHotspot,
     witnesses: prevWitnesses,
     ...prevRest
   } = prevProps
   const {
     mapCenter,
     ownedHotspots,
-    selectedHotspots,
+    selectedHotspot,
     witnesses,
     ...nextRest
   } = nextProps
@@ -423,10 +458,8 @@ export default memo(Map, (prevProps, nextProps) => {
     prevOwnedHotspots || [],
     ownedHotspots || [],
   )
-  const selectedHotspotsEqual = hotspotsEqual(
-    prevSelectedHotspots || [],
-    selectedHotspots || [],
-  )
+  const selectedHotspotEqual =
+    prevSelectedHotspot?.address === selectedHotspot?.address
   const witnessHotspotsEqual = hotspotsEqual(
     prevWitnesses || [],
     witnesses || [],
@@ -435,7 +468,7 @@ export default memo(Map, (prevProps, nextProps) => {
     primitivesEqual &&
     mapCenterEqual &&
     ownedHotspotsEqual &&
-    selectedHotspotsEqual &&
+    selectedHotspotEqual &&
     witnessHotspotsEqual
   )
 })

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -285,6 +285,7 @@ const Map = ({
 
   const defaultCameraSettings = {
     zoomLevel,
+    centerCoordinate: mapCenter,
   }
 
   return (

--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -146,11 +146,14 @@ const HotspotDetails = ({ hotspot }: { hotspot?: Hotspot }) => {
           paddingHorizontal="l"
         >
           <Box flexDirection="row" height={32}>
-            <StatusBadge
-              online={
-                hotspot?.status?.online || hotspotDetailsHotspot?.status?.online
-              }
-            />
+            {hotspot?.status || hotspotDetailsHotspot?.status ? (
+              <StatusBadge
+                online={
+                  hotspot?.status?.online ||
+                  hotspotDetailsHotspot?.status?.online
+                }
+              />
+            ) : null}
             <HexBadge
               rewardScale={
                 hotspot.rewardScale || hotspotDetailsHotspot?.rewardScale

--- a/src/features/hotspots/root/HotspotsEmpty.tsx
+++ b/src/features/hotspots/root/HotspotsEmpty.tsx
@@ -1,36 +1,30 @@
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Linking } from 'react-native'
 import Box from '../../../components/Box'
 import Button from '../../../components/Button'
 import HotspotIcon from '../../../assets/images/blueHotspotIcon.svg'
 import Text from '../../../components/Text'
 import { RootNavigationProp } from '../../../navigation/main/tabTypes'
-import { EXPLORER_BASE_URL } from '../../../utils/config'
 
-const HotspotsEmpty = () => {
+const HotspotsEmpty = ({ onOpenExplorer }: { onOpenExplorer: () => void }) => {
   const { t } = useTranslation()
   const navigation = useNavigation<RootNavigationProp>()
-  const goToExplorer = () => Linking.openURL(`${EXPLORER_BASE_URL}/coverage`)
+  const goToSetup = () => navigation.push('HotspotSetup')
   return (
-    <Box justifyContent="center" flex={1} padding="l">
+    <Box flex={1} padding="l" paddingTop="xl">
       <HotspotIcon />
-      <Text variant="h2" paddingVertical="l">
-        {t('hotspots.owned.title')}
-      </Text>
+      <Text variant="h2">{t('hotspots.owned.title')}</Text>
       <Text variant="subtitleRegular" paddingBottom="l" color="grayText">
         {t('hotspots.empty.body')}
       </Text>
       <Button
-        onPress={() => {
-          navigation.push('HotspotSetup')
-        }}
+        onPress={goToSetup}
         mode="contained"
         variant="primary"
         title={t('hotspots.new.setup')}
       />
-      <Button onPress={goToExplorer} title={t('hotspots.new.explorer')} />
+      <Button onPress={onOpenExplorer} title={t('hotspots.new.explorer')} />
     </Box>
   )
 }

--- a/src/features/hotspots/root/HotspotsEmpty.tsx
+++ b/src/features/hotspots/root/HotspotsEmpty.tsx
@@ -7,14 +7,27 @@ import HotspotIcon from '../../../assets/images/blueHotspotIcon.svg'
 import Text from '../../../components/Text'
 import { RootNavigationProp } from '../../../navigation/main/tabTypes'
 
-const HotspotsEmpty = ({ onOpenExplorer }: { onOpenExplorer: () => void }) => {
+const HotspotsEmpty = ({
+  onOpenExplorer,
+  lightTheme,
+}: {
+  onOpenExplorer?: () => void
+  lightTheme?: boolean
+}) => {
   const { t } = useTranslation()
   const navigation = useNavigation<RootNavigationProp>()
   const goToSetup = () => navigation.push('HotspotSetup')
   return (
-    <Box flex={1} padding="l" paddingTop="xl">
+    <Box padding="l">
       <HotspotIcon />
-      <Text variant="h2">{t('hotspots.owned.title')}</Text>
+      <Text
+        variant="h2"
+        paddingTop="l"
+        paddingBottom="m"
+        color={lightTheme ? 'black' : 'white'}
+      >
+        {t('hotspots.owned.title')}
+      </Text>
       <Text variant="subtitleRegular" paddingBottom="l" color="grayText">
         {t('hotspots.empty.body')}
       </Text>

--- a/src/features/hotspots/root/HotspotsScreen.tsx
+++ b/src/features/hotspots/root/HotspotsScreen.tsx
@@ -19,14 +19,18 @@ const HotspotsScreen = () => {
     setStartOnMap(true)
     const { status } = await Location.requestPermissionsAsync()
     if (status !== 'granted') return
-    const currentLocation = await Location.getCurrentPositionAsync({})
+    const currentLocation = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.High,
+    })
     setLocation(currentLocation)
   }
 
   useAsync(async () => {
     const { status } = await Location.getPermissionsAsync()
     if (status !== 'granted') return
-    const currentLocation = await Location.getCurrentPositionAsync({})
+    const currentLocation = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.High,
+    })
     setLocation(currentLocation)
   }, [])
 

--- a/src/features/hotspots/root/HotspotsScreen.tsx
+++ b/src/features/hotspots/root/HotspotsScreen.tsx
@@ -1,16 +1,52 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 import { useSelector } from 'react-redux'
+import * as Location from 'expo-location'
+import { LocationObject } from 'expo-location'
+import { useAsync } from 'react-async-hook'
 import SafeAreaBox from '../../../components/SafeAreaBox'
 import { RootState } from '../../../store/rootReducer'
 import HotspotsView from './HotspotsView'
+import HotspotsEmpty from './HotspotsEmpty'
+import Box from '../../../components/Box'
 
 const HotspotsScreen = () => {
   const { hotspots } = useSelector((state: RootState) => state.account)
+  const [location, setLocation] = useState<LocationObject>()
+  const [startOnMap, setStartOnMap] = useState(false)
+
+  const getLocation = async () => {
+    setStartOnMap(true)
+    const { status } = await Location.requestPermissionsAsync()
+    if (status !== 'granted') return
+    const currentLocation = await Location.getCurrentPositionAsync({})
+    setLocation(currentLocation)
+  }
+
+  useAsync(async () => {
+    const { status } = await Location.getPermissionsAsync()
+    if (status !== 'granted') return
+    const currentLocation = await Location.getCurrentPositionAsync({})
+    setLocation(currentLocation)
+  }, [])
+
   return (
     <SafeAreaBox backgroundColor="primaryBackground" flex={1} edges={['top']}>
       <BottomSheetModalProvider>
-        <HotspotsView ownedHotspots={hotspots} />
+        {hotspots.length === 0 && !location ? (
+          <Box flex={1} justifyContent="center">
+            <HotspotsEmpty onOpenExplorer={getLocation} />
+          </Box>
+        ) : (
+          <HotspotsView
+            ownedHotspots={hotspots}
+            startOnMap={startOnMap}
+            location={[
+              location?.coords.longitude || 0,
+              location?.coords.latitude || 0,
+            ]}
+          />
+        )}
       </BottomSheetModalProvider>
     </SafeAreaBox>
   )

--- a/src/features/hotspots/root/HotspotsScreen.tsx
+++ b/src/features/hotspots/root/HotspotsScreen.tsx
@@ -1,31 +1,16 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
-import { Hotspot } from '@helium/http'
 import { useSelector } from 'react-redux'
 import SafeAreaBox from '../../../components/SafeAreaBox'
 import { RootState } from '../../../store/rootReducer'
-import HotspotsEmpty from './HotspotsEmpty'
 import HotspotsView from './HotspotsView'
 
 const HotspotsScreen = () => {
-  const {
-    account: { hotspots },
-  } = useSelector((state: RootState) => state)
-  const [ownedHotspots, setOwnedHotspots] = useState<Hotspot[]>([])
-
-  useEffect(() => {
-    if (ownedHotspots.length !== hotspots.length) {
-      setOwnedHotspots(hotspots)
-    }
-  }, [hotspots, ownedHotspots])
-
+  const { hotspots } = useSelector((state: RootState) => state.account)
   return (
     <SafeAreaBox backgroundColor="primaryBackground" flex={1} edges={['top']}>
       <BottomSheetModalProvider>
-        {ownedHotspots.length > 0 && (
-          <HotspotsView ownedHotspots={ownedHotspots} />
-        )}
-        {hotspots.length === 0 && <HotspotsEmpty />}
+        <HotspotsView ownedHotspots={hotspots} />
       </BottomSheetModalProvider>
     </SafeAreaBox>
   )

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -122,11 +122,11 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
 
   const handlePresentDetails = useCallback((hotspot: Hotspot) => {
     setSelectedHotspot(hotspot)
+    setDetailsSnapIndex(1)
     listRef.current?.dismiss()
   }, [])
 
   const handleDismissList = useCallback(() => {
-    setDetailsSnapIndex(0)
     detailsRef.current?.present()
     setListIsDismissed(true)
   }, [])
@@ -142,7 +142,7 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
   }, [focusClosestHotspot, ownedHotspots, startOnMap])
 
   const handleDismissDetails = useCallback(() => {
-    setDetailsSnapIndex(1)
+    setDetailsSnapIndex(0)
     if (listIsDismissed) {
       listRef.current?.present()
       setListIsDismissed(false)

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -132,7 +132,7 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
   }, [])
 
   const handlePressMyHotspots = useCallback(() => {
-    if (ownedHotspots) {
+    if (ownedHotspots && ownedHotspots.length > 0) {
       setSelectedHotspot(ownedHotspots[0])
     } else {
       focusClosestHotspot()
@@ -238,6 +238,7 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
           ownedHotspots={ownedHotspots}
           selectedHotspot={selectedHotspot}
           maxZoomLevel={14}
+          zoomLevel={14}
           witnesses={showWitnesses ? witnesses : []}
           mapCenter={location}
           animationMode="easeTo"

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -36,9 +36,10 @@ import HotspotDetails from '../details/HotspotDetails'
 import { ReAnimatedBox } from '../../../components/AnimatedBox'
 import { useColors } from '../../../theme/themeHooks'
 import BackButton from '../../../components/BackButton'
+import HotspotsEmpty from './HotspotsEmpty'
 
 type Props = {
-  ownedHotspots: Hotspot[]
+  ownedHotspots?: Hotspot[]
 }
 
 const HotspotsView = ({ ownedHotspots }: Props) => {
@@ -72,6 +73,7 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
   } = useSelector((state: RootState) => state)
 
   const [selectedHotspot, setSelectedHotspot] = useState<Hotspot>()
+  const hasHotspots = ownedHotspots && ownedHotspots.length > 0
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('focus', () => {
@@ -91,14 +93,18 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
   }, [])
 
   const handleDismissList = useCallback(() => {
-    setSelectedHotspot(ownedHotspots[0])
+    if (ownedHotspots) {
+      setSelectedHotspot(ownedHotspots[0])
+    }
     setDetailsSnapIndex(0)
     detailsRef.current?.present()
     setListIsDismissed(true)
   }, [ownedHotspots])
 
   const handlePressMyHotspots = useCallback(() => {
-    setSelectedHotspot(ownedHotspots[0])
+    if (ownedHotspots) {
+      setSelectedHotspot(ownedHotspots[0])
+    }
     setDetailsSnapIndex(1)
     detailsRef.current?.present()
   }, [ownedHotspots])
@@ -191,13 +197,15 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
     () => (selectedHotspot && hasLocation ? [selectedHotspot] : undefined),
     [selectedHotspot, hasLocation],
   )
-  const mapCenter = useMemo(
-    () =>
-      selectedHotspot
-        ? [selectedHotspot.lng || 0, selectedHotspot.lat || 0]
-        : [ownedHotspots[0].lng || 0, ownedHotspots[0].lat || 0],
-    [selectedHotspot, ownedHotspots],
-  )
+  const mapCenter = useMemo(() => {
+    if (selectedHotspot) {
+      return [selectedHotspot.lng || 0, selectedHotspot.lat || 0]
+    }
+    if (ownedHotspots && ownedHotspots[0]) {
+      return [ownedHotspots[0].lng || 0, ownedHotspots[0].lat || 0]
+    }
+    return [0, 0]
+  }, [selectedHotspot, ownedHotspots])
 
   return (
     <Box flex={1} flexDirection="column" justifyContent="space-between">
@@ -249,7 +257,9 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
               <HotspotIcon />
             </Box>
             <Text variant="body1Bold" color="white">
-              {t('hotspots.owned.title')}
+              {hasHotspots
+                ? t('hotspots.owned.title')
+                : t('hotspots.owned.title_no_hotspots')}
             </Text>
           </TouchableOpacityBox>
         </ReAnimatedBox>
@@ -267,7 +277,11 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
             onPress={handleBack}
           />
         ) : (
-          <Text variant="h3">{t('hotspots.owned.title')}</Text>
+          <Text variant="h3">
+            {hasHotspots
+              ? t('hotspots.owned.title')
+              : t('hotspots.owned.title_no_hotspots')}
+          </Text>
         )}
 
         <Box flexDirection="row" justifyContent="space-between">
@@ -295,7 +309,11 @@ const HotspotsView = ({ ownedHotspots }: Props) => {
         onDismiss={handleDismissList}
         animatedIndex={animatedListPosition}
       >
-        <HotspotsList onSelectHotspot={handlePresentDetails} />
+        {hasHotspots ? (
+          <HotspotsList onSelectHotspot={handlePresentDetails} />
+        ) : (
+          <HotspotsEmpty onOpenExplorer={handleDismissList} />
+        )}
       </BottomSheetModal>
 
       <BottomSheetModal

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -95,7 +95,7 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [listIsDismissed])
+  }, [listIsDismissed, networkHotspots])
 
   useEffect(() => {
     if (hasHotspots) {

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -221,19 +221,6 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
       selectedHotspot?.lat !== undefined && selectedHotspot?.lng !== undefined
     )
   }, [selectedHotspot])
-  const selectedHotspots = useMemo(
-    () => (selectedHotspot && hasLocation ? [selectedHotspot] : undefined),
-    [selectedHotspot, hasLocation],
-  )
-  const mapCenter = useMemo(() => {
-    if (selectedHotspot) {
-      return [selectedHotspot.lng || 0, selectedHotspot.lat || 0]
-    }
-    if (ownedHotspots && ownedHotspots[0]) {
-      return [ownedHotspots[0].lng || 0, ownedHotspots[0].lat || 0]
-    }
-    return location || [0, 0]
-  }, [selectedHotspot, ownedHotspots, location])
 
   return (
     <Box flex={1} flexDirection="column" justifyContent="space-between">
@@ -249,13 +236,12 @@ const HotspotsView = ({ ownedHotspots, startOnMap, location }: Props) => {
       >
         <Map
           ownedHotspots={ownedHotspots}
-          selectedHotspots={selectedHotspots}
-          zoomLevel={14}
-          mapCenter={mapCenter}
+          selectedHotspot={selectedHotspot}
+          maxZoomLevel={14}
           witnesses={showWitnesses ? witnesses : []}
+          mapCenter={location}
           animationMode="easeTo"
-          animationDuration={500}
-          offsetCenterRatio={2.2}
+          animationDuration={800}
           onFeatureSelected={onMapHotspotSelected}
           interactive={hasLocation}
           showNoLocation={!hasLocation}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -565,7 +565,7 @@ export default {
       subtitle:
         'If you just added a Hotspot, hang tight. It takes a few moments for the Network to propagate the Hotspot.',
       setup: 'Set up Hotspot',
-      explorer: 'Global Hotspot Explorer',
+      explorer: 'View Hotspots Around Me',
     },
     owned: {
       title: 'My Hotspots',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -569,6 +569,7 @@ export default {
     },
     owned: {
       title: 'My Hotspots',
+      title_no_hotspots: 'Hotspots',
       reward_summary: 'Your Hotspot mined {{hntAmount}} in the past 24 hours.',
       reward_summary_plural:
         'Your {{count}} Hotspots mined {{hntAmount}} in the past 24 hours.',

--- a/src/utils/appDataClient.ts
+++ b/src/utils/appDataClient.ts
@@ -1,10 +1,10 @@
 import Client, {
   AnyTransaction,
+  Bucket,
   Hotspot,
+  NaturalDate,
   PendingTransaction,
   ResourceList,
-  Bucket,
-  NaturalDate,
 } from '@helium/http'
 import { Transaction } from '@helium/transactions'
 import {


### PR DESCRIPTION
closes #337 
closes #314 
closes #184 

Allows users without hotspots in their to view hotspots around them. This will be more beneficial when we also add the ability to favorite hotspot.

This also makes some changes to the map so that you retain your selected hotspot if you go back and forth. So if I select one and go back to the list and then swipe the list down the map no longer resets. It will reset when you hit "My Hotspots", but I did that by design and we could also keep the previous state if we wanted instead.

Currently the flow works as so
1. If you open the app and have not enabled location permission you see the current hotspot empty screen (no bottom sheet or map)
2. When you enable location you jump into the map at your location. If you permanently enable location you will now start on the bottom sheet and have the ability to see the map.
3. If users only enable permission one time then they will continue to see the old static hotspots page (no bottom sheet or map)


https://user-images.githubusercontent.com/6345962/110196774-a8f7af80-7dfb-11eb-93c2-a16c535ddc4b.mov


