### PR TITLE
remove legacy hotspot type

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
     "redux-thunk": "^2.3.0",
     "rn-sliding-up-panel": "^2.4.4",
     "use-debounce": "^5.2.0",
-    "use-state-with-callback": "^2.0.3",
-    "validator": "^13.5.1"
+    "use-state-with-callback": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/features/hotspots/settings/HotspotDiagnosticReport.tsx
+++ b/src/features/hotspots/settings/HotspotDiagnosticReport.tsx
@@ -73,16 +73,14 @@ const HotspotDiagnosticReport = ({ onFinished }: Props) => {
   const { version } = useDevice()
   const { t } = useTranslation()
   const {
-    connectedHotspot: {
-      activity: {
-        challenge_activity: { data: challenges },
-      },
-      type,
-      firmware,
-      address,
+    activity: {
+      challenge_activity: { data: challenges },
     },
-    heliumData: { blockHeight },
-  } = useSelector((state: RootState) => state)
+    firmware,
+    address,
+    onboardingRecord,
+  } = useSelector((state: RootState) => state.connectedHotspot)
+  const { blockHeight } = useSelector((state: RootState) => state.heliumData)
   const dispatch = useAppDispatch()
   const { enableBack } = useHotspotSettingsContext()
 
@@ -107,7 +105,7 @@ const HotspotDiagnosticReport = ({ onFinished }: Props) => {
     setLineItems([
       {
         attribute: t('hotspot_settings.diagnostics.hotspot_type'),
-        value: type,
+        value: onboardingRecord?.maker?.name || 'Unknown',
       },
       {
         attribute: t('hotspot_settings.diagnostics.firmware'),
@@ -138,7 +136,14 @@ const HotspotDiagnosticReport = ({ onFinished }: Props) => {
         value: format(fromUnixTime(info.currentTime), DF),
       },
     ])
-  }, [diagnostics, firmware, t, type, version, info.currentTime])
+  }, [
+    diagnostics,
+    firmware,
+    t,
+    version,
+    info.currentTime,
+    onboardingRecord?.maker?.name,
+  ])
 
   useEffect(() => {
     if (!firmware?.version) {
@@ -212,7 +217,7 @@ const HotspotDiagnosticReport = ({ onFinished }: Props) => {
       lastChallengeDate: format(fromUnixTime(info.lastChallengeTime), DF),
       reportGenerated: format(fromUnixTime(info.currentTime), DF),
       gateway: address || '',
-      hotspotType: type || '',
+      hotspotMaker: onboardingRecord?.maker?.name || 'Unknown',
       appVersion: version,
     })
   }

--- a/src/features/hotspots/settings/sendReport.ts
+++ b/src/features/hotspots/settings/sendReport.ts
@@ -16,7 +16,7 @@ export default async ({
   lastChallengeDate,
   reportGenerated,
   gateway,
-  hotspotType,
+  hotspotMaker,
   appVersion,
 }: {
   eth: string
@@ -30,7 +30,7 @@ export default async ({
   lastChallengeDate: string
   reportGenerated: string
   gateway: string
-  hotspotType: string
+  hotspotMaker: string
   appVersion: string
 }) => {
   const deviceNameAndOS = () => {
@@ -44,7 +44,7 @@ export default async ({
 
   const body = [
     `Hotspot: ${kebabCase(animalHash(gateway))}`,
-    `Hotspot Type: ${hotspotType}`,
+    `Hotspot Maker: ${hotspotMaker}`,
     `Address: ${gateway}`,
     `Connected to Blockchain: ${connected}`,
     `Dialable: ${dialable}`,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -668,7 +668,7 @@ export default {
       last_challenged_help:
         'Neighboring Hotspots have not been able to verify your Hotspot location. In most cases, this is because the antenna is in an area where radio signals can’t reach (buildings blocking, antenna pointed down, antenna indoors).',
       firmware: 'Hotspot Firmware',
-      hotspot_type: 'Hotspot Type',
+      hotspot_type: 'Hotspot Maker',
       app_version: 'App Version',
       wifi_mac: 'Wi-Fi MAC',
       eth_mac: 'Ethernet MAC',

--- a/src/store/connectedHotspot/connectedHotspotSlice.ts
+++ b/src/store/connectedHotspot/connectedHotspotSlice.ts
@@ -34,8 +34,6 @@ export type HotspotDetails = {
   mac?: string
   address?: string
   wifi?: string
-  type?: HotspotType
-  name?: HotspotName
   onboardingRecord?: OnboardingRecord
   onboardingAddress?: string
   firmware?: {

--- a/src/utils/useHotspot.ts
+++ b/src/utils/useHotspot.ts
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react'
 import { BleError, Device, Subscription } from 'react-native-ble-plx'
-import validator from 'validator'
 import compareVersions from 'compare-versions'
 import { Balance, CurrencyType } from '@helium/currency'
 import { useSelector } from 'react-redux'
@@ -32,9 +31,7 @@ import { calculateAddGatewayFee, calculateAssertLocFee } from './fees'
 import connectedHotspotSlice, {
   AllHotspotDetails,
   fetchHotspotDetails,
-  HotspotName,
   HotspotStatus,
-  HotspotType,
 } from '../store/connectedHotspot/connectedHotspotSlice'
 import { useAppDispatch } from '../store/store'
 import { RootState } from '../store/rootReducer'
@@ -73,34 +70,6 @@ const useHotspot = () => {
   } = useSelector((state: RootState) => state)
 
   // TODO: Move staking calls to redux
-
-  // helium hotspot uses b58 onboarding address and RAK is uuid v4
-  const getHotspotType = (onboardingAddress: string): HotspotType =>
-    validator.isUUID(addUuidDashes(onboardingAddress)) ? 'RAK' : 'Helium'
-
-  const addUuidDashes = (s = '') =>
-    `${s.substr(0, 8)}-${s.substr(8, 4)}-${s.substr(12, 4)}-${s.substr(
-      16,
-      4,
-    )}-${s.substr(20)}`
-
-  const getHotspotName = (type: HotspotType): HotspotName => {
-    switch (type) {
-      case 'RAK':
-        return 'RAK Hotspot Miner'
-      case 'NEBRAIN':
-        return 'Nebra Indoor Hotspot'
-      case 'NEBRAOUT':
-        return 'Nebra Indoor Hotspot'
-      case 'Bobcat':
-        return 'Bobcat Miner 300'
-      case 'SYNCROBIT':
-        return 'SyncroB.it Hotspot'
-      default:
-      case 'Helium':
-        return 'Helium Hotspot'
-    }
-  }
 
   const scanForHotspots = async (ms: number) => {
     setAvailableHotspots({})
@@ -174,8 +143,6 @@ const useHotspot = () => {
       HotspotCharacteristic.ONBOARDING_KEY_UUID,
     )
 
-    const type = getHotspotType(onboardingAddress || '')
-    const name = getHotspotName(type)
     const mac = hotspotDevice.localName?.slice(15)
 
     if (!onboardingAddress || onboardingAddress.length < 20) {
@@ -187,8 +154,6 @@ const useHotspot = () => {
     const details = {
       address,
       mac,
-      type,
-      name,
       wifi,
       ethernetOnline,
       onboardingAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11731,11 +11731,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.5.1:
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.5.2.tgz#c97ae63ed4224999fb6f42c91eaca9567fe69a46"
-  integrity sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==
-
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
Removes the old hotspot type that was calculated from onboarding address formatting which no longer works.

Replaces it with the onboarding maker name. In the case there is no maker name (DYI or something goes wrong) it will show 'unknown' in diagnostics.