### PR TITLE
update location permission string and fix state not clearing on logout

### DIFF
--- a/ios/Helium/Info.plist
+++ b/ios/Helium/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Allow Helium to use your location to add your Helium Hotspots to the network</string>
+	<string>Allow Helium to use your location to add your Helium Hotspots to the network and explore Hotspots around you</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Allow Helium to authenticate with Face ID</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/ios/Helium/Info.plist
+++ b/ios/Helium/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Allow Helium to use your location to add your Helium Hotspots to the network and explore Hotspots around you</string>
+	<string>Allow Helium to use your location to add Hotspots to the network and explore Hotspots around you</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Allow Helium to authenticate with Face ID</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -741,8 +741,8 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: a3acb8812d6adf127deb0a5edae2793b97e6b641
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
-  Folly: aeb27d02cdff07ca01f8a8a5a6dd5bcaf6be6f70
-  glog: 2ad46e202fbaa5641fceb4b2af37dcd88fd8762d
+  Folly: b73c3869541e86821df3c387eb0af5f65addfab4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
   lottie-react-native: 1fb4ce21d6ad37dab8343eaff8719df76035bd93
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956

--- a/src/navigation/NavigationRoot.tsx
+++ b/src/navigation/NavigationRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, memo } from 'react'
+import React, { memo, useCallback, useEffect } from 'react'
 import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import { useSelector } from 'react-redux'
@@ -9,7 +9,8 @@ import defaultScreenOptions from './defaultScreenOptions'
 import RootNav from './main/HomeNavigator'
 import { useColors } from '../theme/themeHooks'
 
-const RootStack = createStackNavigator()
+const OnboardingStack = createStackNavigator()
+const MainStack = createStackNavigator()
 
 const NavigationRoot = () => {
   const { isBackedUp } = useSelector((state: RootState) => state.app)
@@ -22,26 +23,29 @@ const NavigationRoot = () => {
   const currentScreen = useCallback(() => {
     if (!isBackedUp)
       return (
-        <RootStack.Screen
-          name="Onboarding"
-          component={Onboarding}
-          options={{ gestureEnabled: false }}
-        />
+        <OnboardingStack.Navigator
+          headerMode="none"
+          screenOptions={defaultScreenOptions}
+        >
+          <OnboardingStack.Screen
+            name="Onboarding"
+            component={Onboarding}
+            options={{ gestureEnabled: false }}
+          />
+        </OnboardingStack.Navigator>
       )
 
-    return <RootStack.Screen name="MainTab" component={RootNav} />
-  }, [isBackedUp])
-
-  return (
-    <NavigationContainer>
-      <RootStack.Navigator
+    return (
+      <MainStack.Navigator
         headerMode="none"
         screenOptions={defaultScreenOptions}
       >
-        {currentScreen()}
-      </RootStack.Navigator>
-    </NavigationContainer>
-  )
+        <MainStack.Screen name="MainTab" component={RootNav} />
+      </MainStack.Navigator>
+    )
+  }, [isBackedUp])
+
+  return <NavigationContainer>{currentScreen()}</NavigationContainer>
 }
 
 export default memo(NavigationRoot)


### PR DESCRIPTION
closes #370 

I think state of the map / some of the components remains on logout and log back in right away since they are in the same stack, components may not unmount. 

Coco ran into this problem but I couldn't get it to happen on my device. I moved each stack to its own navigator to see if maybe that helps.