### PR TITLE
add onesignal account tags

### DIFF
--- a/src/store/user/appSlice.ts
+++ b/src/store/user/appSlice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { AppStateStatus } from 'react-native'
+import OneSignal from 'react-native-onesignal'
 import {
   deleteSecureItem,
   getSecureItem,
@@ -61,9 +62,15 @@ export const restoreUser = createAsyncThunk<Restore>(
       getSecureItem('authInterval'),
       getSecureItem('hapticDisabled'),
       getSecureItem('convertHntToCurrency'),
+      getSecureItem('address'),
     ])
+    const isBackedUp = vals[0]
+    const address = vals[6]
+    if (isBackedUp && address) {
+      OneSignal.sendTags({ address })
+    }
     return {
-      isBackedUp: vals[0],
+      isBackedUp,
       isPinRequired: vals[1],
       isPinRequiredForPayment: vals[2],
       authInterval: vals[3] ? parseInt(vals[3], 10) : Intervals.IMMEDIATELY,

--- a/src/utils/secureAccount.ts
+++ b/src/utils/secureAccount.ts
@@ -1,5 +1,6 @@
 import { Address, Keypair, Mnemonic } from '@helium/crypto-react-native'
 import * as SecureStore from 'expo-secure-store'
+import OneSignal from 'react-native-onesignal'
 import * as Logger from './logger'
 
 type AccountStoreKey = BooleanKey | StringKey
@@ -56,6 +57,7 @@ export const createKeypair = async (
   }
   const { keypair: keypairRaw, address } = await Keypair.fromMnemonic(mnemonic)
 
+  OneSignal.sendTags({ address: address.b58 })
   Logger.setUser(address.b58)
 
   await Promise.all([
@@ -130,5 +132,9 @@ export const getWalletApiToken = async () => {
   return apiToken
 }
 
-export const signOut = async () =>
-  Promise.all([...stringKeys, ...boolKeys].map((key) => deleteSecureItem(key)))
+export const signOut = async () => {
+  OneSignal.deleteTag('address')
+  return Promise.all(
+    [...stringKeys, ...boolKeys].map((key) => deleteSecureItem(key)),
+  )
+}


### PR DESCRIPTION
We were missing the onesignal tags for account data.

- I think this would lead to notifications not working on devices that were never on the V2 app 
- Deleting the tag should resolve the issue of notifications being sent to devices that have logged out of an account

closes https://github.com/helium/wallet-api/issues/22

