### PR TITLE
remove patch install from build script

### DIFF
--- a/appcenter-pre-build.sh
+++ b/appcenter-pre-build.sh
@@ -7,5 +7,3 @@ echo STAKING_API_BASE_URL=$STAKING_API_BASE_URL >> .env
 echo WALLET_API_BASE_URL=$WALLET_API_BASE_URL >> .env
 echo SENTRY_DSN=$SENTRY_DSN >> .env
 echo GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY >> .env
-
-yarn patch-install


### PR DESCRIPTION
After the update to reanimated v2 we no longer need the patch and I removed it but forgot to remove the patch install from the app center build script.