### PR TITLE
Fix transfer modal on android

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -17,6 +17,7 @@ type Props = {
   locked?: boolean
   defaultValue?: string
   value?: string
+  numberOfLines?: number
 }
 
 const InputField = ({
@@ -29,6 +30,7 @@ const InputField = ({
   locked = false,
   defaultValue,
   value,
+  numberOfLines,
 }: Props) => {
   const inputRef = useRef<TextInput | null>(null)
 
@@ -73,6 +75,7 @@ const InputField = ({
             keyboardAppearance="dark"
             keyboardType={type}
             value={value}
+            numberOfLines={numberOfLines}
             style={{
               fontFamily: 'InputMono-Regular',
               fontSize: 15,

--- a/src/features/hotspots/settings/HotspotSettings.tsx
+++ b/src/features/hotspots/settings/HotspotSettings.tsx
@@ -305,11 +305,9 @@ const HotspotSettings = ({ hotspot }: Props) => {
           margin="ms"
           style={{ transform: [{ translateY: slideUpAnimRef.current }] }}
         >
-          {settingsState !== 'transfer' && (
-            <Text variant="h2" lineHeight={27} color="white" marginBottom="ms">
-              {title}
-            </Text>
-          )}
+          <Text variant="h2" lineHeight={27} color="white" marginBottom="ms">
+            {title}
+          </Text>
 
           {settingsState !== 'scan' && (
             <KeyboardAvoidingView

--- a/src/features/wallet/send/SendForm.tsx
+++ b/src/features/wallet/send/SendForm.tsx
@@ -229,6 +229,7 @@ const SendForm = ({
         defaultValue={amount}
         onChange={onAmountChange}
         value={amount}
+        numberOfLines={2}
         label={t('send.amount.label_transfer')}
         placeholder={t('send.amount.placeholder_transfer')}
       />


### PR DESCRIPTION
- The transfer modal animation was causing the dialog to disappear. Keeping a UI element above it, the title causes it to remain in view
- Fixes the transfer send form amount text clipped on Android