### PR TITLE
Submit transactions through wallet-api

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -736,8 +736,8 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: a3acb8812d6adf127deb0a5edae2793b97e6b641
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
-  Folly: aeb27d02cdff07ca01f8a8a5a6dd5bcaf6be6f70
-  glog: 2ad46e202fbaa5641fceb4b2af37dcd88fd8762d
+  Folly: b73c3869541e86821df3c387eb0af5f65addfab4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
   lottie-react-native: 1fb4ce21d6ad37dab8343eaff8719df76035bd93
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956

--- a/src/features/notifications/NotificationItem.tsx
+++ b/src/features/notifications/NotificationItem.tsx
@@ -2,10 +2,10 @@ import React, { memo } from 'react'
 import { formatDistance, fromUnixTime } from 'date-fns'
 import { useTranslation } from 'react-i18next'
 import Box from '../../components/Box'
-import HeliumBubble from '../../assets/images/heliumBubble.svg'
 import Text from '../../components/Text'
 import { Notification } from '../../store/account/accountSlice'
 import TouchableOpacityBox from '../../components/TouchableOpacityBox'
+import ImageBox from '../../components/ImageBox'
 
 type Props = {
   notification: Notification
@@ -31,7 +31,15 @@ const NotificationItem = ({
         alignItems="flex-end"
         marginBottom={isLast ? 's' : 'none'}
       >
-        <HeliumBubble />
+        <ImageBox
+          source={{
+            uri: notification.icon,
+            method: 'GET',
+          }}
+          resizeMode="contain"
+          width={46}
+          height={46}
+        />
         <TouchableOpacityBox
           activeOpacity={0.9}
           marginLeft="s"

--- a/src/hooks/useSubmitTxn.ts
+++ b/src/hooks/useSubmitTxn.ts
@@ -42,7 +42,7 @@ const useSubmitTxn = (): Submitter => {
     const serializedTxn = txn.toString()
 
     // submit to blockchain
-    const { data: apiResponse } = await postWallet('transactions', {
+    const apiResponse = await postWallet('transactions', {
       txn: serializedTxn,
     })
     const pendingTxn = new PendingTransaction(apiResponse)

--- a/src/hooks/useSubmitTxn.ts
+++ b/src/hooks/useSubmitTxn.ts
@@ -1,11 +1,12 @@
 import Balance, { CurrencyType } from '@helium/currency'
 import {
-  PendingTransaction,
+  PendingTransaction as PendingTransactionType,
   PaymentV2 as HttpPaymentV2,
   AssertLocationV1 as HttpAssertLocationV1,
   AddGatewayV1 as HttpAddGatewayV1,
   TransferHotspotV1 as HttpTransferHotspotV1,
 } from '@helium/http'
+import PendingTransaction from '@helium/http/build/models/PendingTransaction'
 import {
   AddGatewayV1,
   AssertLocationV1,
@@ -18,7 +19,7 @@ import { useSelector } from 'react-redux'
 import activitySlice from '../store/activity/activitySlice'
 import { RootState } from '../store/rootReducer'
 import { useAppDispatch } from '../store/store'
-import { submitTransaction } from '../utils/appDataClient'
+import { postWallet } from '../utils/walletClient'
 
 type SignableTransaction =
   | PaymentV2
@@ -27,7 +28,7 @@ type SignableTransaction =
   | TokenBurnV1
   | TransferHotspotV1
 
-type Submitter = (txn: SignableTransaction) => Promise<PendingTransaction>
+type Submitter = (txn: SignableTransaction) => Promise<PendingTransactionType>
 
 const useSubmitTxn = (): Submitter => {
   const dispatch = useAppDispatch()
@@ -41,7 +42,10 @@ const useSubmitTxn = (): Submitter => {
     const serializedTxn = txn.toString()
 
     // submit to blockchain
-    const pendingTxn = await submitTransaction(serializedTxn)
+    const { data: apiResponse } = await postWallet('transactions', {
+      txn: serializedTxn,
+    })
+    const pendingTxn = new PendingTransaction(apiResponse)
 
     // construct mock pending txn
     pendingTxn.type = txn.type

--- a/src/utils/appDataClient.ts
+++ b/src/utils/appDataClient.ts
@@ -114,9 +114,6 @@ export const getAccount = async (address?: string) => {
 
 export const getBlockHeight = () => client.blocks.getHeight()
 
-export const submitTransaction = async (serializedTxn: string) =>
-  client.transactions.submit(serializedTxn)
-
 export const getCurrentOraclePrice = async () => client.oracle.getCurrentPrice()
 
 export const getPredictedOraclePrice = async () =>

--- a/src/utils/walletClient.ts
+++ b/src/utils/walletClient.ts
@@ -12,7 +12,8 @@ const makeRequest = async (url: string, opts: RequestInit) => {
       throw new Error('no token')
     }
 
-    const route = [Config.WALLET_API_BASE_URL, url].join('/')
+    // const route = [Config.WALLET_API_BASE_URL, url].join('/')
+    const route = ['http://localhost:4000/api', url].join('/')
 
     const response = await fetch(route, {
       ...opts,

--- a/src/utils/walletClient.ts
+++ b/src/utils/walletClient.ts
@@ -12,8 +12,7 @@ const makeRequest = async (url: string, opts: RequestInit) => {
       throw new Error('no token')
     }
 
-    // const route = [Config.WALLET_API_BASE_URL, url].join('/')
-    const route = ['http://localhost:4000/api', url].join('/')
+    const route = [Config.WALLET_API_BASE_URL, url].join('/')
 
     const response = await fetch(route, {
       ...opts,


### PR DESCRIPTION
This submits all transactions through wallet-api rather than to the api directly.

Note that we'll want to wait to merge this until the wallet api change has been deployed.

It also changes the notification list item to use the notification icon url that is supplied with each notification. I updated all of the icon url references in wallet api to use the new styles going forward.