### PR TITLE
Fix "Last Challenge" date shown as beginning of Unix time instead of "never"

### DIFF
--- a/src/features/hotspots/settings/HotspotDiagnosticReport.tsx
+++ b/src/features/hotspots/settings/HotspotDiagnosticReport.tsx
@@ -213,7 +213,10 @@ const HotspotDiagnosticReport = ({ onFinished }: Props) => {
       natType: capitalize(diagnostics?.nat_type || ''),
       ip: capitalize(diagnostics?.ip || ''),
       height: info.height.toLocaleString(locale),
-      lastChallengeDate: format(fromUnixTime(info.lastChallengeTime), DF),
+      lastChallengeDate:
+        info.lastChallengeTime === 0
+          ? 'never'
+          : format(fromUnixTime(info.lastChallengeTime), DF),
       reportGenerated: format(fromUnixTime(info.currentTime), DF),
       gateway: address || '',
       hotspotMaker: onboardingRecord?.maker?.name || 'Unknown',


### PR DESCRIPTION
Fixes https://github.com/helium/hotspot-app/issues/424

If a hotspot does not have any challenges, export the "last challenge" as "never" in diagnostic reports instead of start of unix time (1970-01-01).