### PR TITLE
add support for rewards_v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@gorhom/bottom-sheet": "^3.4.1",
     "@helium/crypto-react-native": "^3.9.0",
     "@helium/currency": "^3.25.1",
-    "@helium/http": "^3.25.1",
+    "@helium/http": "^3.26.0",
     "@helium/proto-ble": "3.10.0",
     "@helium/transactions": "^3.20.0",
     "@react-native-community/art": "^1.2.0",

--- a/src/features/hotspots/root/hotspotTypes.tsx
+++ b/src/features/hotspots/root/hotspotTypes.tsx
@@ -20,7 +20,7 @@ export type HotspotActivityType = typeof HotspotActivityKeys[number]
 
 export const HotspotActivityFilters = {
   all: [],
-  rewards: ['rewards_v1'],
+  rewards: ['rewards_v1', 'rewards_v2'],
   challenge_activity: ['poc_receipts_v1'],
   data_transfer: ['state_channel_close_v1'],
   challenge_construction: ['poc_request_v1'],

--- a/src/features/wallet/root/ActivityDetails/Rewards.tsx
+++ b/src/features/wallet/root/ActivityDetails/Rewards.tsx
@@ -6,7 +6,7 @@ import Box from '../../../../components/Box'
 
 type Props = { item: AnyTransaction | PendingTransaction }
 const Rewards = ({ item }: Props) => {
-  if (!(item.type in ['rewards_v1', 'rewards_v2'])) return null
+  if (!['rewards_v1', 'rewards_v2'].includes(item.type)) return null
 
   const rewards = item as RewardsV1
 

--- a/src/features/wallet/root/ActivityDetails/Rewards.tsx
+++ b/src/features/wallet/root/ActivityDetails/Rewards.tsx
@@ -6,7 +6,7 @@ import Box from '../../../../components/Box'
 
 type Props = { item: AnyTransaction | PendingTransaction }
 const Rewards = ({ item }: Props) => {
-  if (item.type !== 'rewards_v1') return null
+  if (!(item.type in ['rewards_v1', 'rewards_v2'])) return null
 
   const rewards = item as RewardsV1
 

--- a/src/features/wallet/root/useActivityItem.tsx
+++ b/src/features/wallet/root/useActivityItem.tsx
@@ -8,6 +8,7 @@ import {
   PaymentV2,
   PendingTransaction,
   RewardsV1,
+  RewardsV2,
   TokenBurnV1,
   TransferHotspotV1,
 } from '@helium/http'
@@ -30,9 +31,6 @@ import useCurrency from '../../../utils/useCurrency'
 import { Colors } from '../../../theme/theme'
 import { getMakerName } from '../../../utils/stakingClient'
 import { RootState } from '../../../store/rootReducer'
-
-// TODO import from helium-js once released
-class RewardsV2 extends RewardsV1 {}
 
 export const TxnTypeKeys = [
   'rewards_v1',

--- a/src/features/wallet/root/useActivityItem.tsx
+++ b/src/features/wallet/root/useActivityItem.tsx
@@ -31,8 +31,12 @@ import { Colors } from '../../../theme/theme'
 import { getMakerName } from '../../../utils/stakingClient'
 import { RootState } from '../../../store/rootReducer'
 
+// TODO import from helium-js once released
+class RewardsV2 extends RewardsV1 {}
+
 export const TxnTypeKeys = [
   'rewards_v1',
+  'rewards_v2',
   'payment_v1',
   'payment_v2',
   'add_gateway_v1',
@@ -101,6 +105,7 @@ const useActivityItem = (
       case 'assert_location_v1':
         return 'purpleMuted'
       case 'rewards_v1':
+      case 'rewards_v2':
         return 'purpleBright'
       case 'token_burn_v1':
         return 'orange'
@@ -130,6 +135,7 @@ const useActivityItem = (
           ? t('transactions.transferSell')
           : t('transactions.transferBuy')
       case 'rewards_v1':
+      case 'rewards_v2':
         return t('transactions.mining')
       case 'token_burn_v1':
         return t('transactions.burnHNT')
@@ -150,6 +156,7 @@ const useActivityItem = (
       case 'assert_location_v1':
         return <Location width={20} height={23} />
       case 'rewards_v1':
+      case 'rewards_v2':
         return <Rewards width={26} height={26} />
       case 'token_burn_v1':
         return <Burn width={23} height={28} />
@@ -171,6 +178,7 @@ const useActivityItem = (
       case 'assert_location_v1':
         return <Location width={20} height={23} />
       case 'rewards_v1':
+      case 'rewards_v2':
         return <Rewards width={26} height={26} />
       case 'token_burn_v1':
         return <Burn width={23} height={28} />
@@ -186,7 +194,7 @@ const useActivityItem = (
       return isSending
     }
 
-    if (item instanceof RewardsV1) {
+    if (item instanceof RewardsV1 || item instanceof RewardsV2) {
       return false
     }
 
@@ -229,7 +237,7 @@ const useActivityItem = (
   )
 
   const fee = useMemo(async () => {
-    if (item instanceof RewardsV1) {
+    if (item instanceof RewardsV1 || item instanceof RewardsV2) {
       return ''
     }
 
@@ -277,7 +285,7 @@ const useActivityItem = (
     if (item instanceof TokenBurnV1) {
       return formatAmount('-', item.amount)
     }
-    if (item instanceof RewardsV1) {
+    if (item instanceof RewardsV1 || item instanceof RewardsV2) {
       return formatAmount('+', item.totalAmount)
     }
     if (item instanceof PaymentV1) {

--- a/src/features/wallet/root/walletTypes.ts
+++ b/src/features/wallet/root/walletTypes.ts
@@ -9,7 +9,7 @@ export type FilterType = typeof FilterKeys[number]
 
 export const Filters = {
   all: [],
-  mining: ['rewards_v1'],
+  mining: ['rewards_v1', 'rewards_v2'],
   payment: ['payment_v1', 'payment_v2'],
   hotspot: ['add_gateway_v1', 'assert_location_v1', 'transfer_hotspot_v1'],
   pending: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,10 +1244,10 @@
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.25.1":
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.25.1.tgz#d2817d05f84bf22d6780e4ca8019433971997418"
-  integrity sha512-5Fr6b0GMmoe3FJgH2YVUpuZ153H9Tarzqs6TC7nW5riGv0tQWMkcCRFMdabxuzKupIESQnmrudSAJl+I1b3WPg==
+"@helium/http@^3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.26.0.tgz#ccb662034690429a5ef4b5bfed0ddacf5712b007"
+  integrity sha512-H4lNiK/IlHHYn+ZuWTlr8psKzoEZRnLN3o95/cndV7qEdHjZ9MUW1BuimOwrUYAd7qyhjZEquCM2eTBC3OZPuw==
   dependencies:
     "@helium/currency" "^3.25.1"
     axios "^0.21.1"


### PR DESCRIPTION
adds support for `rewards_v2` transactions which the API should display the same as `rewards_v1`. 

depends on: https://github.com/helium/helium-js/pull/152