### PR TITLE
fix hotspot filter scrolling issues

### DIFF
--- a/src/components/BubbleSelect.tsx
+++ b/src/components/BubbleSelect.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet'
+import { ScrollView } from 'react-native-gesture-handler'
 import { BoxProps } from '@shopify/restyle'
 import React, { memo, useCallback } from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
@@ -29,7 +29,7 @@ const BubbleSelect = ({
 
   return (
     <Box>
-      <BottomSheetScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
         <Box {...boxProps} flexDirection="row" flex={1} height={33}>
           {data.map((item, index) => (
             <BubbleSelectItem
@@ -40,7 +40,7 @@ const BubbleSelect = ({
             />
           ))}
         </Box>
-      </BottomSheetScrollView>
+      </ScrollView>
       <LinearGradient {...leftGradientProps} />
       <LinearGradient {...rightGradientProps} />
     </Box>


### PR DESCRIPTION
Looks like the bottom sheet provided components only work for vertical scroll, so we need to use the gesture handler ones for horizontal.

https://github.com/gorhom/react-native-bottom-sheet/issues/46#issuecomment-708386676