### PR TITLE
Revert "Set android target and compile sdk to 30."

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 29
+        targetSdkVersion = 29
     }
     repositories {
         google()


### PR DESCRIPTION
Reverts helium/hotspot-app#482

This was causing crashes on some Android 11 devices.