### PR TITLE
Fix Paring->Pairing typo

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -692,7 +692,7 @@ export default {
     title: 'Hotspot Settings',
     pairing: {
       title: 'Update Wi-Fi or Run Diagnostics',
-      subtitle: 'Paring required before proceeding.',
+      subtitle: 'Pairing required before proceeding.',
       scan: 'Pair',
     },
     transfer: {


### PR DESCRIPTION
Pairing was misspelled.