### PR TITLE
clear onboarding state when starting hotspot setup

### DIFF
--- a/src/features/hotspots/setup/HotspotSelectionScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSelectionScreen.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList } from 'react-native-gesture-handler'
 import { Edge } from 'react-native-safe-area-context'
@@ -24,6 +24,11 @@ const HotspotSetupSelectionScreen = () => {
   const navigation = useNavigation<HotspotSetupNavigationProp>()
   const dispatch = useAppDispatch()
   const edges = useMemo((): Edge[] => ['top', 'left', 'right'], [])
+
+  // clear any existing onboarding state
+  useEffect(() => {
+    dispatch(hotspotOnboardingSlice.actions.reset())
+  }, [dispatch])
 
   const handlePress = useCallback(
     (hotspotType: HotspotType) => () => {

--- a/src/store/hotspots/hotspotOnboardingSlice.ts
+++ b/src/store/hotspots/hotspotOnboardingSlice.ts
@@ -34,6 +34,9 @@ const hotspotOnboardingSlice = createSlice({
     setLocationName(state, action: PayloadAction<string>) {
       state.locationName = action.payload
     },
+    reset() {
+      return initialState
+    },
   },
 })
 


### PR DESCRIPTION
This fixes a bug when onboarding two hotspots in a row and setting location for the first but skipping location for the second.

closes #522 