### PR TITLE
update connect failed dialog

### DIFF
--- a/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
+++ b/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
@@ -126,7 +126,7 @@ const HotspotDiagnosticsConnection = ({ onConnected }: Props) => {
         onConnected(hotspot)
       } else {
         handleConnectFailure(
-          'hotspot_setup.onboarding_error.subtitle',
+          'hotspot_setup.onboarding_error.body_connect_failed',
           'hotspot_setup.onboarding_error.title_connect_failed',
         )
       }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -348,7 +348,9 @@ export default {
       next: 'Exit Setup',
       disconnected:
         'There was an error connecting to the Hotspot. Please try again.',
-      title_connect_failed: 'Unable to Proceed',
+      title_connect_failed: 'Hotspot Pairing Failed',
+      body_connect_failed:
+        'Hotspot Miner is unable to respond to requests. Please reboot the Hotspot and try again later.',
     },
     add_hotspot: {
       title: 'Add Hotspot',


### PR DESCRIPTION
closes #593 

Hotspots are failing to connect with the ongoing hotspot / mine issues and once those are resolved this error should clear up.

I am updating the error message to better fit the case:

title: "Hotspot Pairing Failed"
message: "Hotspot Miner is unable to respond to requests. Please reboot the Hotspot and try again later."