### PR TITLE
URL-decode the deep link received transaction

### DIFF
--- a/src/providers/AppLinkProvider.tsx
+++ b/src/providers/AppLinkProvider.tsx
@@ -92,7 +92,7 @@ const useAppLink = () => {
           const { address: txnStr } = record as AppLink
           if (!txnStr) return
 
-          navigator.confirmAddGateway(txnStr)
+          navigator.confirmAddGateway(decodeURIComponent(txnStr))
           break
         }
       }


### PR DESCRIPTION
the transaction is sent from an app link, e.g. `helium://add_gateway/XXX`
this path shall not contain any slash, so the incoming transaction (in base64) must be URL-encoded to be safely passed
this change will URL-decode the received transaction so that it is valid base64

e.g.
```
helium://add_gateway/CroBCiEAd9p%2FZOinDi87
```
transaction string is `CroBCiEAd9p%2FZOinDi87`
real base64 string is `CroBCiEAd9p/ZOinDi87`