### PR TITLE
ensure notification markup uses proper quotes

### DIFF
--- a/src/utils/parseMarkup.tsx
+++ b/src/utils/parseMarkup.tsx
@@ -54,7 +54,7 @@ const parseMarkup = (
     return rawText
   }
 
-  const doc = parse5.parse(rawText) as DefaultTreeParentNode
+  const doc = parse5.parse(rawText.replace('“', '"')) as DefaultTreeParentNode
   const body = (doc.childNodes[0] as DefaultTreeParentNode)
     .childNodes[1] as DefaultTreeParentNode
   const values = body.childNodes.map(parseNode).flat(Infinity)


### PR DESCRIPTION
Notifications were sometimes using `“` vs `"` and it throws off the parsing for markup.

closes #704 