### PR TITLE
Fix support for QR-scanned multi-payments

### DIFF
--- a/src/providers/AppLinkProvider.tsx
+++ b/src/providers/AppLinkProvider.tsx
@@ -147,7 +147,8 @@ const useAppLink = () => {
    * (1) A helium deeplink URL
    * (2) address string
    * (3) stringified JSON object { type, address, amount?, memo? }
-   * (4) stringified JSON object { type, payees: {[payeeAddress]: { amount, memo? }} }
+   * (4) stringified JSON object { type, payees: {[payeeAddress]: amount} }
+   * (5) stringified JSON object { type, payees: {[payeeAddress]: { amount, memo? }} }
    */
   const parseBarCodeData = useCallback(
     (data: string, scanType: AppLinkCategoryType): AppLink | AppLinkPayment => {
@@ -211,11 +212,26 @@ const useAppLink = () => {
             scanResult = {
               type,
               payees: Object.entries(rawScanResult.payees).map((entries) => {
-                const scanData = entries[1] as { amount: string; memo?: string }
+                let amount
+                let memo
+                if (entries[1]) {
+                  if (typeof entries[1] === 'number') {
+                    // Case (4) stringified JSON object { type, payees: {[payeeAddress]: amount} }
+                    amount = entries[1] as number
+                  } else if (typeof entries[1] === 'object') {
+                    // Case (5) stringified JSON object { type, payees: {[payeeAddress]: { amount, memo? }} }
+                    const scanData = entries[1] as {
+                      amount: string
+                      memo?: string
+                    }
+                    amount = scanData.amount
+                    memo = scanData.memo
+                  }
+                }
                 return {
                   address: entries[0],
-                  amount: scanData.amount,
-                  memo: scanData.memo,
+                  amount: `${amount}`,
+                  memo,
                 } as Payee
               }),
             }


### PR DESCRIPTION
## Summary
Currently, the QR scanning feature in "Send" supports multiple payments per-transaction if the QR code data is formatted exactly as follows:
```typescript
{
  type: string
  payees: {
    [payeeAddress]: { amount: string, memo?: string },
    [payeeAddress]: { amount: string, memo?: string },
    ...
  }
}
```
However, it does not fully support the following
```typescript
{
  type: string
  payees: {
    [payeeAddress]: amount,
    [payeeAddress]: amount,
    ...
  }
}
```
In the case above, only the address is pre-filled in the "Send" view (amount field remains blank).

This PR adds back support for the latter format which is helpful when submitting a large number of payments (the more payments you can squeeze into a QR code the better, so if you don't need memos then the latter format is more concise). This also updates support for the former format so that amount can be passed as a string or a number (currently, if passed as a number, the app crashes when trying to format it as if it was a string).