### PR TITLE
fix content pill crash on Android

### DIFF
--- a/src/components/ContentPill.tsx
+++ b/src/components/ContentPill.tsx
@@ -128,7 +128,7 @@ const ContentPill = ({
     const nextWidth = data.length * ITEM_SIZE + padding * 2
     if (nextWidth === viewWidth) return
 
-    animateTransition('ContentPill.AnimateWidth')
+    animateTransition('ContentPill.AnimateWidth', false)
     setViewWidth(nextWidth)
   }, [data.length, listContentStyle, viewWidth])
 


### PR DESCRIPTION
When tapping through witnesses content pill would crash due to the animateTransition call.

closes #696 