### PR TITLE
Add conditions to reduce status banner display frequency

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ import SecurityScreen from './features/security/SecurityScreen'
 import { fetchFeatures } from './store/features/featuresSlice'
 import usePrevious from './utils/usePrevious'
 import StatusBanner from './components/StatusBanner'
-import { fetchStatus } from './store/helium/heliumStatusSlice'
 import notificationSlice, {
   fetchNotifications,
 } from './store/notifications/notificationSlice'
@@ -83,7 +82,6 @@ const App = () => {
   const loadInitialData = useCallback(() => {
     dispatch(fetchBlockHeight())
     dispatch(fetchInitialData())
-    dispatch(fetchStatus())
     dispatch(fetchNotifications())
   }, [dispatch])
 

--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -1,26 +1,88 @@
-import React from 'react'
-import FlashMessage, { hideMessage } from 'react-native-flash-message'
+import React, { memo, useEffect, useCallback, useMemo } from 'react'
+import FlashMessage, {
+  hideMessage,
+  Icon,
+  showMessage,
+} from 'react-native-flash-message'
 import { Linking } from 'react-native'
+import useAppState from 'react-native-appstate-hook'
+import { useSelector } from 'react-redux'
+import { formatDistanceToNow } from 'date-fns'
+import { useTranslation } from 'react-i18next'
 import TouchableOpacityBox from './TouchableOpacityBox'
 import Close from '../assets/images/closeModal.svg'
 import { HELIUM_STATUS_URL } from '../utils/StatusClient'
+import { useAppDispatch } from '../store/store'
+import { fetchIncidents } from '../store/helium/heliumStatusSlice'
+import { RootState } from '../store/rootReducer'
+import shortLocale from '../utils/formatDistance'
 
 const onTapStatusBanner = async () => {
   await Linking.openURL(HELIUM_STATUS_URL)
 }
 
-const StatusBanner = () => (
-  <FlashMessage
-    position="top"
-    autoHide={false}
-    icon={{ icon: 'danger', position: 'right' }}
-    onPress={onTapStatusBanner}
-    renderFlashMessageIcon={() => (
-      <TouchableOpacityBox onPress={hideMessage} padding="xs">
+const StatusBanner = () => {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const incidents = useSelector((state: RootState) => state.status.incidents)
+
+  useAppState({
+    onForeground: () => {
+      dispatch(fetchIncidents())
+    },
+  })
+
+  const getAlertDescription = useCallback(
+    (timestamp: string) => {
+      return t('statusBanner.description', {
+        date: formatDistanceToNow(new Date(timestamp), {
+          locale: shortLocale,
+          addSuffix: true,
+        }),
+      })
+    },
+    [t],
+  )
+
+  useEffect(() => {
+    if (!incidents.length) return
+
+    const [lastIncident] = incidents
+
+    showMessage({
+      type: lastIncident.impact === 'critical' ? 'danger' : 'warning',
+      message: lastIncident.name,
+      description: getAlertDescription(lastIncident.updated_at),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incidents])
+
+  const icon = useCallback(() => {
+    return (
+      <TouchableOpacityBox
+        onPress={hideMessage}
+        padding="xs"
+        hitSlop={{ top: 8, left: 8, bottom: 8, right: 8 }}
+      >
         <Close color="white" width={30} height={30} />
       </TouchableOpacityBox>
-    )}
-  />
-)
+    )
+  }, [])
 
-export default StatusBanner
+  const iconStyle = useMemo(
+    () => ({ icon: 'danger', position: 'right' } as Icon),
+    [],
+  )
+
+  return (
+    <FlashMessage
+      position="top"
+      autoHide={false}
+      icon={iconStyle}
+      onPress={onTapStatusBanner}
+      renderFlashMessageIcon={icon}
+    />
+  )
+}
+
+export default memo(StatusBanner)

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1047,4 +1047,7 @@ export default {
     title: 'Map Filters',
     button: 'Choose Map Filter',
   },
+  statusBanner: {
+    description: 'Last updated {{date}}. Tap for info.',
+  },
 }

--- a/src/store/discovery/discoverySlice.ts
+++ b/src/store/discovery/discoverySlice.ts
@@ -31,7 +31,7 @@ export const fetchRecentDiscoveries = createAsyncThunk<
   RecentDiscoveryInfo,
   { hotspotAddress: string }
 >('discovery/recent', async ({ hotspotAddress }) =>
-  getWallet(`discoveries/${hotspotAddress}`, null, true),
+  getWallet(`discoveries/${hotspotAddress}`, null, { camelCase: true }),
 )
 
 export const startDiscovery = createAsyncThunk<
@@ -46,7 +46,7 @@ export const startDiscovery = createAsyncThunk<
       hotspot_name: hotspotName,
       signature,
     },
-    true,
+    { camelCase: true },
   )
 })
 
@@ -54,7 +54,9 @@ export const fetchDiscoveryById = createAsyncThunk<
   DiscoveryRequest | null,
   { requestId: number }
 >('discovery/fetch', async ({ requestId }) => {
-  return getWallet(`discoveries/responses/${requestId}`, null, true)
+  return getWallet(`discoveries/responses/${requestId}`, null, {
+    camelCase: true,
+  })
 })
 
 // This slice contains data related to discovery mode

--- a/src/store/helium/heliumStatusSlice.ts
+++ b/src/store/helium/heliumStatusSlice.ts
@@ -1,67 +1,85 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { showMessage } from 'react-native-flash-message'
-import { formatDistanceToNow } from 'date-fns'
-import { getIncidents, getStatus } from '../../utils/StatusClient'
-import { Incident, Status, StatusInfo } from './StatusTypes'
-import shortLocale from '../../utils/formatDistance'
+import AsyncStorage from '@react-native-community/async-storage'
+import { getIncidents } from '../../utils/StatusClient'
+import { Incident, StatusInfo } from './StatusTypes'
+
+const STATUS_KEY = 'statusKey'
+const ONBOARDING_COMPONENT_ID = '74lkk1qwp5xq'
+const APP_COMPONENT_ID = 'qfcq2xt6v0xm'
+const COMPONENT_IDS = [ONBOARDING_COMPONENT_ID, APP_COMPONENT_ID]
+const INCIDENT_STATUSES = [
+  'investigating',
+  'identified',
+  'scheduled',
+  'in_progress',
+  'verifying',
+]
+
+type StoredIncident = {
+  id: string
+  status: string
+}
 
 export type HeliumStatusState = {
-  status: {
-    page?: StatusInfo
-    status?: Status
-  }
-  incidents: {
-    page?: StatusInfo
-    incidents?: Incident[]
-  }
-}
-const initialState: HeliumStatusState = {
-  status: {},
-  incidents: {},
-}
-
-const getAlertDescription = (timestamp: string) => {
-  return `Last updated ${formatDistanceToNow(new Date(timestamp), {
-    locale: shortLocale,
-    addSuffix: true,
-  })}. Tap for info.`
-}
-
-export const fetchStatus = createAsyncThunk<{
-  page: StatusInfo
-  status: Status
-}>('heliumStatus/fetchStatus', async () => getStatus())
-
-export const fetchIncidents = createAsyncThunk<{
-  page: StatusInfo
+  page?: StatusInfo
   incidents: Incident[]
-}>('heliumStatus/fetchIncidents', async () => getIncidents())
+}
+
+const initialState: HeliumStatusState = {
+  incidents: [],
+}
+
+export const fetchIncidents = createAsyncThunk(
+  'heliumStatus/fetchIncidents',
+  async () => {
+    let storedIncidents: StoredIncident[] = []
+    const storedIncidentsStr = await AsyncStorage.getItem(STATUS_KEY)
+    if (storedIncidentsStr) {
+      storedIncidents = JSON.parse(storedIncidentsStr) as StoredIncident[]
+    }
+    const incidents: {
+      page: StatusInfo
+      incidents: Incident[]
+    } = await getIncidents()
+    return {
+      storedIncidents,
+      ...incidents,
+    }
+  },
+)
 
 const heliumStatusSlice = createSlice({
   name: 'heliumStatus',
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(fetchStatus.fulfilled, (state, { payload }) => {
-      state.status = payload
-      if (payload?.status?.indicator && payload?.status?.indicator !== 'none') {
-        showMessage({
-          type: payload.status.indicator === 'critical' ? 'danger' : 'warning',
-          message: payload.status.description,
-          description: getAlertDescription(payload.page.updated_at),
-        })
-      }
-    })
     builder.addCase(fetchIncidents.fulfilled, (state, { payload }) => {
-      state.incidents = payload
-      const lastIncident = payload?.incidents[0]
-      if (lastIncident?.impact && lastIncident?.impact !== 'none') {
-        showMessage({
-          type: lastIncident.impact === 'critical' ? 'danger' : 'warning',
-          message: lastIncident.name,
-          description: getAlertDescription(lastIncident.updated_at),
-        })
-      }
+      const incidents = payload.incidents.flatMap((incident) => {
+        if (
+          // verify this incident belongs to at least one relevant component
+          !incident.components.find(({ id }) => COMPONENT_IDS.includes(id)) ||
+          // verify the status is one we want to show
+          !INCIDENT_STATUSES.includes(incident.status) ||
+          // make sure we haven't already shown this incident/status
+          payload.storedIncidents.find(
+            ({ id, status }) =>
+              id === incident.id && status === incident.status,
+          )
+        ) {
+          return []
+        }
+        return [incident]
+      })
+
+      const nextStoredIncidents = [
+        ...incidents.map(({ id, status }) => ({ id, status })),
+        ...payload.storedIncidents,
+      ].slice(0, 20) // limit number of stored incidents. This is just an arbitrary number. May need adjustment.
+
+      AsyncStorage.setItem(STATUS_KEY, JSON.stringify(nextStoredIncidents))
+
+      state.incidents = incidents
+      state.page = payload.page
     })
   },
 })

--- a/src/store/hotspots/hotspotsSlice.ts
+++ b/src/store/hotspots/hotspotsSlice.ts
@@ -206,7 +206,9 @@ export const fetchHotspotsData = createAsyncThunk(
 
     const hotspotPromises = [getHotspots()]
     if (followEnabled) {
-      hotspotPromises.push(getWallet('hotspots/follow', null, true))
+      hotspotPromises.push(
+        getWallet('hotspots/follow', null, { camelCase: true }),
+      )
     }
     const allHotspots = await Promise.all(
       hotspotPromises.map((p) =>
@@ -237,11 +239,9 @@ export const followHotspot = createAsyncThunk<
   },
   string
 >('hotspots/followHotspot', async (hotspotAddress) => {
-  const followed = await postWallet(
-    `hotspots/follow/${hotspotAddress}`,
-    null,
-    true,
-  )
+  const followed = await postWallet(`hotspots/follow/${hotspotAddress}`, null, {
+    camelCase: true,
+  })
   let blockHotspot: Hotspot | null = null
   try {
     blockHotspot = await getHotspotDetails(hotspotAddress)
@@ -270,7 +270,7 @@ export const unfollowHotspot = createAsyncThunk<Hotspot[], string>(
     const followed = await deleteWallet(
       `hotspots/follow/${hotspot_address}`,
       null,
-      true,
+      { camelCase: true },
     )
     return sanitizeWalletHotspots(followed)
   },

--- a/src/utils/StatusClient.ts
+++ b/src/utils/StatusClient.ts
@@ -36,6 +36,4 @@ const makeRequest = async (url: string, opts: RequestInit = {}) => {
   }
 }
 
-export const getStatus = async () => makeRequest('status.json')
-
 export const getIncidents = async () => makeRequest('incidents/unresolved.json')

--- a/src/utils/walletClient.ts
+++ b/src/utils/walletClient.ts
@@ -52,7 +52,7 @@ const makeRequest = async (url: string, opts: RequestInit) => {
 export const getWallet = async (
   url: string,
   params?: unknown,
-  camelCase = false,
+  { camelCase } = { camelCase: false },
 ) => {
   let fullUrl = url
   if (params) {
@@ -71,7 +71,7 @@ export const getWallet = async (
 export const postWallet = async (
   url: string,
   data?: unknown,
-  camelCase = false,
+  { camelCase } = { camelCase: false },
 ) => {
   const opts = {
     method: 'POST',
@@ -87,7 +87,7 @@ export const postWallet = async (
 export const deleteWallet = async (
   url: string,
   data?: unknown,
-  camelCase = false,
+  { camelCase } = { camelCase: false },
 ) => {
   const opts = {
     method: 'DELETE',

--- a/src/utils/walletClient.ts
+++ b/src/utils/walletClient.ts
@@ -27,7 +27,7 @@ const makeRequest = async (url: string, opts: RequestInit) => {
     })
 
     if (!response.ok) {
-      const errorMessage = `Bad response, status:${response.status} message:${response.statusText}`
+      const errorMessage = `Bad response, status:${response.status} message:${response.statusText} ${opts.method} url:${route}`
       Logger.breadcrumb(errorMessage, breadcrumbOpts)
       throw new Error(errorMessage)
     }


### PR DESCRIPTION
Remove ui concerns from slice to status component.
Only show relevant incidents.
Persist incidents. Only show ones we haven't before.
Remove status fetching and data.
Localize banner description.

Closes #735 