### PR TITLE
Fix infinite loop when deep linking to hotspot.

### DIFF
--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -282,7 +282,8 @@ const HotspotsView = ({
     }
 
     fetchHotspot()
-  }, [dispatch, handlePresentDetails, params])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params])
 
   const handleSelectPlace = useCallback(
     async (place: PlacePrediction) => {


### PR DESCRIPTION
`helium://hotspot/:address`