### PR TITLE
Make iPad build fullscreen

### DIFF
--- a/ios/Helium.xcodeproj/project.pbxproj
+++ b/ios/Helium.xcodeproj/project.pbxproj
@@ -798,6 +798,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Helium-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -826,6 +827,7 @@
 				PRODUCT_NAME = Helium;
 				SWIFT_OBJC_BRIDGING_HEADER = "Helium-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/src/features/hotspots/root/HotspotsTicker.tsx
+++ b/src/features/hotspots/root/HotspotsTicker.tsx
@@ -17,6 +17,7 @@ import { useTextVariants } from '../../../theme/themeHooks'
 import { Theme } from '../../../theme/theme'
 import { locale } from '../../../utils/i18n'
 import useVisible from '../../../utils/useVisible'
+import { isTablet } from 'react-native-device-info'
 
 type Props = BoxProps<Theme>
 const HotspotsTicker = ({ ...boxProps }: Props) => {
@@ -82,7 +83,7 @@ const HotspotsTicker = ({ ...boxProps }: Props) => {
         repeatSpacer={0}
         easing={Easing.linear}
       >
-        {text}
+        {isTablet() ? text + text : text}
       </TextTicker>
     </Box>
   )

--- a/src/features/onboarding/welcome/WelcomeScreen.tsx
+++ b/src/features/onboarding/welcome/WelcomeScreen.tsx
@@ -7,21 +7,28 @@ import { OnboardingNavigationProp } from '../onboardingTypes'
 import Box from '../../../components/Box'
 import ImageBox from '../../../components/ImageBox'
 import TextTransform from '../../../components/TextTransform'
+import { isTablet } from 'react-native-device-info'
 
 const WelcomeScreen = () => {
   const { t } = useTranslation()
   const navigation = useNavigation<OnboardingNavigationProp>()
 
   return (
-    <Box backgroundColor="primaryBackground" flex={1}>
+    <Box backgroundColor="primaryBackground" flex={1} >
+      <Box
+        flex={2}
+        height={"100%"}
+      >
       <ImageBox
-        alignSelf="flex-end"
-        maxHeight="50%"
+        flex={1}
+        alignSelf={isTablet() ? "flex-end" : "auto"}
+        maxHeight="100%"
         resizeMode="contain"
         aspectRatio={1242 / 1340}
-        width="100%"
+        width="50%"
         source={require('../../../assets/images/welcome.png')}
       />
+      </Box>
       <Box
         flex={1}
         paddingVertical="l"


### PR DESCRIPTION
This change allows the app to run fullscreen on iPad instead of a scaled down window.

Before:
<img width="659" alt="Screenshot 2021-07-26 at 10 25 36" src="https://user-images.githubusercontent.com/693770/126958852-71535adf-448f-4a8c-a4fe-27ec0937f8c7.png">

after:
<img width="1117" alt="grafik" src="https://user-images.githubusercontent.com/693770/126965410-19228676-a6ec-4d55-a39d-70cc8cb72ee3.png">

I quickly checked other screns in the app and they looked fine.