### PR TITLE
fix comma disabled for samsung text input

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement, useRef } from 'react'
-import { TextInput, TouchableWithoutFeedback } from 'react-native'
+import {
+  KeyboardTypeOptions,
+  TextInput,
+  TouchableWithoutFeedback,
+} from 'react-native'
 import Box from './Box'
 import Text from './Text'
 import InputLock from '../assets/images/input-lock.svg'
@@ -12,7 +16,7 @@ type Props = {
   placeholder?: string
   extra?: ReactElement
   footer?: ReactElement
-  type?: 'default' | 'numeric'
+  type?: KeyboardTypeOptions
   onChange: (text: string) => void
   locked?: boolean
   defaultValue?: string
@@ -79,6 +83,7 @@ const InputField = ({
             blurOnSubmit
             autoCompleteType="off"
             textContentType="none"
+            autoCapitalize="none"
             autoCorrect={false}
             dataDetectorTypes="none"
             keyboardAppearance="dark"

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -79,7 +79,6 @@ const InputField = ({
             blurOnSubmit
             autoCompleteType="off"
             textContentType="none"
-            autoCapitalize="none"
             autoCorrect={false}
             dataDetectorTypes="none"
             keyboardAppearance="dark"

--- a/src/features/wallet/send/SendDetailsForm.tsx
+++ b/src/features/wallet/send/SendDetailsForm.tsx
@@ -212,7 +212,7 @@ const SendDetailsForm = ({
         footer={<AddressAliasFooter addressAlias={addressAlias} />}
       />
       <InputField
-        type="numeric"
+        type="decimal-pad"
         testID="AmountInput"
         defaultValue={amount}
         onChange={setFormAmount}
@@ -281,7 +281,7 @@ const SendDetailsForm = ({
         }
       />
       <InputField
-        type="numeric"
+        type="decimal-pad"
         defaultValue={amount}
         onChange={setAmount}
         value={amount}
@@ -329,7 +329,7 @@ const SendDetailsForm = ({
         }
       />
       <InputField
-        type="numeric"
+        type="decimal-pad"
         defaultValue={amount}
         onChange={setFormAmount}
         value={amount}


### PR DESCRIPTION
When entering payment amounts the comma was disabled for samsung keyboards. 

related: 
https://github.com/facebook/react-native/issues/12988
https://github.com/facebook/react-native/issues/22005

closes #765 