### PR TITLE
remove memo from HotspotChecklistCarousel

### DIFF
--- a/src/features/hotspots/checklist/HotspotChecklistCarousel.tsx
+++ b/src/features/hotspots/checklist/HotspotChecklistCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Carousel, Pagination } from 'react-native-snap-carousel'
 import { Dimensions, Platform } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
@@ -108,4 +108,4 @@ const HotspotChecklistCarousel = ({
   )
 }
 
-export default memo(HotspotChecklistCarousel)
+export default HotspotChecklistCarousel

--- a/src/features/hotspots/checklist/HotspotChecklistItem.tsx
+++ b/src/features/hotspots/checklist/HotspotChecklistItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '../../../components/Box'
 import Text from '../../../components/Text'
@@ -205,4 +205,4 @@ const HotspotChecklistItem = ({
   )
 }
 
-export default memo(HotspotChecklistItem)
+export default HotspotChecklistItem


### PR DESCRIPTION
Removing component memo from HotspotChecklistCarousel, it still has memo built into the variables and we can re-render anytime props change. 

Hopefully resolves #817 