### PR TITLE
fix lint error

### DIFF
--- a/src/makers/linxdot/hotspots.ts
+++ b/src/makers/linxdot/hotspots.ts
@@ -56,7 +56,6 @@ const Linxdot = {
       ],
     },
   },
-  icon: HotspotIcon,
   antenna: { default: ANTENNAS.LINXDOT },
 } as MakerHotspot
 


### PR DESCRIPTION
The icon property got duplicated, probably a merge error. Not sure how it built on the PR but its failing now so this removes the duplicate.