### PR TITLE
fix fee display for free assert when updating hotspot

### DIFF
--- a/src/features/hotspots/settings/updateHotspot/UpdateHotspotConfig.tsx
+++ b/src/features/hotspots/settings/updateHotspot/UpdateHotspotConfig.tsx
@@ -117,12 +117,18 @@ const UpdateHotspotConfig = ({ onClose, onCloseSettings, hotspot }: Props) => {
     name: string,
   ) => {
     if (updatedLocation) {
-      const feeData = await loadLocationFeeData()
+      const feeData = await loadLocationFeeData(
+        hotspot?.nonce,
+        undefined,
+        onboardingRecord,
+      )
       setLocationFee(
-        feeData.totalStakingAmountDC.toString(0, {
-          groupSeparator,
-          decimalSeparator,
-        }),
+        feeData.isFree
+          ? '0 DC'
+          : feeData.totalStakingAmountDC.toString(0, {
+              groupSeparator,
+              decimalSeparator,
+            }),
       )
       setFullScreen(false)
       enableBack(onClose)


### PR DESCRIPTION
The fee for free asserts on the confirm page when updating a hotspot was showing 1,055,000 DC when it should show 0 DC