### PR TITLE
Sigh add_gateway transaction when qr/web onboarding is chosen

### DIFF
--- a/src/features/hotspots/setup/HotspotTxnsProgressScreen.tsx
+++ b/src/features/hotspots/setup/HotspotTxnsProgressScreen.tsx
@@ -19,6 +19,8 @@ import { HotspotErrorCode } from '../../../utils/useHotspot'
 import { assertLocationTxn } from '../../../utils/assertLocationUtils'
 import useSubmitTxn from '../../../hooks/useSubmitTxn'
 import { HotspotSetupStackParamList } from './hotspotSetupTypes'
+import { getKeypair } from '../../../utils/secureAccount'
+import { getStakingSignedTransaction } from '../../../utils/stakingClient'
 
 type Route = RouteProp<HotspotSetupStackParamList, 'HotspotTxnsProgressScreen'>
 
@@ -99,10 +101,34 @@ const HotspotTxnsProgressScreen = () => {
       // if so, construct and publish add gateway
 
       if (qrAddGatewayTxn) {
+        if (!address) {
+          showOKAlert({
+            titleKey: 'hotspot_setup.onboarding_error.title',
+            messageKey: 'hotspot_setup.onboarding_error.disconnected',
+          })
+          return
+        }
+
         // Gateway Txn scanned from QR
         try {
-          const addGateway = AddGatewayV1.fromString(qrAddGatewayTxn)
-          await submitTxn(addGateway)
+          const txn = AddGatewayV1.fromString(qrAddGatewayTxn)
+
+          const keypair = await getKeypair()
+
+          const txnOwnerSigned = await txn.sign({
+            owner: keypair,
+          })
+
+          const stakingServerSignedTxnStr = await getStakingSignedTransaction(
+            address,
+            txnOwnerSigned.toString(),
+          )
+
+          const stakingServerSignedTxn = AddGatewayV1.fromString(
+            stakingServerSignedTxnStr,
+          )
+
+          await submitTxn(stakingServerSignedTxn)
         } catch (error) {
           handleError(error, 'add_gateway')
           return


### PR DESCRIPTION
When the qr/web onboarding flow is chosen a transaction constantly fails with the bad_owner_signature reason. 
There are two steps missing comparing to the bluetooth onboarding flow:
- the transaction should be signed by the owner
- the transaction should be signed by stacking server
This PR adds these two steps   