### PR TITLE
Allow data only hotspots to update antenna details.

### DIFF
--- a/src/features/hotspots/settings/updateHotspot/UpdateHotspotConfig.tsx
+++ b/src/features/hotspots/settings/updateHotspot/UpdateHotspotConfig.tsx
@@ -209,8 +209,6 @@ const UpdateHotspotConfig = ({ onClose, onCloseSettings, hotspot }: Props) => {
   }
 
   const StatePicker = () => {
-    if (isDataOnly(hotspot)) return null
-
     return (
       <Box flexDirection="row" borderRadius="m">
         <TouchableOpacityBox


### PR DESCRIPTION
Closes #890

@cokes518 I had the ability to update antenna details removed for data-only hotspots. This PR will bring that capability back. Just want to be sure this is what we want.