### PR TITLE
Feature/account settings

### DIFF
--- a/src/features/hotspots/root/HotspotsPicker.tsx
+++ b/src/features/hotspots/root/HotspotsPicker.tsx
@@ -27,7 +27,7 @@ const HotspotsPicker = ({ visible }: Props) => {
   const spacing = useSpacing()
   const maybeGetLocation = useGetLocation()
   const fleetModeEnabled = useSelector(
-    (state: RootState) => state.app.isFleetModeEnabled,
+    (state: RootState) => state.account.settings.isFleetModeEnabled,
   )
   const order = useSelector((state: RootState) => state.hotspots.order)
 

--- a/src/features/hotspots/root/HotspotsScreen.tsx
+++ b/src/features/hotspots/root/HotspotsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react'
+import React, { useEffect, useState, useMemo, useCallback, memo } from 'react'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 import { useSelector } from 'react-redux'
 import { ActivityIndicator } from 'react-native'
@@ -13,7 +13,7 @@ import useVisible from '../../../utils/useVisible'
 import { useAppDispatch } from '../../../store/store'
 import useGetLocation from '../../../utils/useGetLocation'
 import useAlert from '../../../utils/useAlert'
-import appSlice from '../../../store/user/appSlice'
+import { updateFleetModeEnabled } from '../../../store/account/accountSlice'
 
 const HotspotsScreen = () => {
   const maybeGetLocation = useGetLocation()
@@ -32,10 +32,10 @@ const HotspotsScreen = () => {
     (state: RootState) => state.hotspots.hotspotsLoaded,
   )
   const fleetModeEnabled = useSelector(
-    (state: RootState) => state.app.isFleetModeEnabled,
+    (state: RootState) => state.account.settings.isFleetModeEnabled,
   )
   const hasFleetModeAutoEnabled = useSelector(
-    (state: RootState) => state.app.hasFleetModeAutoEnabled,
+    (state: RootState) => state.account.settings.hasFleetModeAutoEnabled,
   )
   const fleetModeLowerLimit = useSelector(
     (state: RootState) => state.features.fleetModeLowerLimit,
@@ -68,7 +68,7 @@ const HotspotsScreen = () => {
       return
 
     dispatch(
-      appSlice.actions.updateFleetModeEnabled({
+      updateFleetModeEnabled({
         enabled: true,
         autoEnabled: true,
       }),
@@ -128,4 +128,4 @@ const HotspotsScreen = () => {
   )
 }
 
-export default HotspotsScreen
+export default memo(HotspotsScreen)

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -90,7 +90,7 @@ const HotspotsView = ({
   })
   const [detailHeight, setDetailHeight] = useState(0)
   const fleetModeEnabled = useSelector(
-    (state: RootState) => state.app.isFleetModeEnabled,
+    (state: RootState) => state.account.settings.isFleetModeEnabled,
   )
   const hotspotsForHexId = useSelector(
     (state: RootState) => state.discovery.hotspotsForHexId,

--- a/src/features/notifications/NotificationsScreen.tsx
+++ b/src/features/notifications/NotificationsScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
 import { useSelector } from 'react-redux'
+import { Edge } from 'react-native-safe-area-context'
 import SafeAreaBox from '../../components/SafeAreaBox'
 import { RootState } from '../../store/rootReducer'
 import { useAppDispatch } from '../../store/store'
@@ -44,12 +45,10 @@ const NotificationsScreen = () => {
     [dispatch],
   )
 
+  const edges = useMemo(() => ['top', 'left', 'right'] as Edge[], [])
+
   return (
-    <SafeAreaBox
-      backgroundColor="primaryBackground"
-      edges={['top', 'left', 'right']}
-      flex={1}
-    >
+    <SafeAreaBox backgroundColor="primaryBackground" edges={edges} flex={1}>
       <NotificationList
         notifications={notifications}
         loadingNotification={loadingNotification}

--- a/src/store/helium/heliumDataSlice.ts
+++ b/src/store/helium/heliumDataSlice.ts
@@ -8,7 +8,6 @@ import {
   getStatCounts,
 } from '../../utils/appDataClient'
 import { getCurrentPrices } from '../../utils/coinGeckoClient'
-import { signOut } from '../../utils/secureAccount'
 import { getMakers, Maker } from '../../utils/stakingClient'
 
 export type HeliumDataState = {
@@ -66,12 +65,7 @@ export const fetchInitialData = createAsyncThunk<HeliumDataState>(
 const heliumDataSlice = createSlice({
   name: 'heliumData',
   initialState,
-  reducers: {
-    signOut: () => {
-      signOut()
-      return { ...initialState, isRestored: true }
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder.addCase(fetchInitialData.fulfilled, (state, { payload }) => {
       state.currentOraclePrice = payload.currentOraclePrice

--- a/src/store/helium/heliumDataSlice.ts
+++ b/src/store/helium/heliumDataSlice.ts
@@ -46,17 +46,27 @@ export const fetchStats = createAsyncThunk('heliumData/stats', async () =>
 export const fetchInitialData = createAsyncThunk<HeliumDataState>(
   'heliumData/fetchInitialData',
   async () => {
+    console.log('load initial data')
     const vals = await Promise.all([
       getCurrentOraclePrice(),
       getPredictedOraclePrice(),
       getCurrentPrices(),
       getMakers(),
+      getBlockHeight(),
     ])
+    const [
+      currentOraclePrice,
+      predictedOraclePrices,
+      currentPrices,
+      makers,
+      blockHeight,
+    ] = vals
     return {
-      currentOraclePrice: vals[0],
-      predictedOraclePrices: vals[1],
-      currentPrices: vals[2],
-      makers: vals[3],
+      currentOraclePrice,
+      predictedOraclePrices,
+      currentPrices,
+      makers,
+      blockHeight,
     }
   },
 )
@@ -72,6 +82,7 @@ const heliumDataSlice = createSlice({
       state.predictedOraclePrices = payload.predictedOraclePrices
       state.currentPrices = payload.currentPrices
       state.makers = payload.makers
+      state.blockHeight = payload.blockHeight
     })
     builder.addCase(fetchBlockHeight.fulfilled, (state, { payload }) => {
       // this is happening on an interval, only update if there's a change

--- a/src/store/hotspots/hotspotsSlice.ts
+++ b/src/store/hotspots/hotspotsSlice.ts
@@ -96,6 +96,7 @@ export const fetchRewards = createAsyncThunk<
     const ownedAddresses = hotspots.map((h) => h.address)
     gatewayAddresses = uniq([...ownedAddresses, ...gatewayAddresses])
   }
+  if (gatewayAddresses.length === 0) return []
 
   if (gatewayAddresses.length === 0) {
     return []

--- a/src/store/user/appSlice.ts
+++ b/src/store/user/appSlice.ts
@@ -12,9 +12,6 @@ import { Intervals } from '../../features/moreTab/more/useAuthIntervals'
 export type AppState = {
   isBackedUp: boolean
   isHapticDisabled: boolean
-  isFleetModeEnabled: boolean
-  hasFleetModeAutoEnabled: boolean
-  convertHntToCurrency: boolean
   isSettingUpHotspot: boolean
   isRestored: boolean
   isPinRequired: boolean
@@ -27,8 +24,6 @@ export type AppState = {
 const initialState: AppState = {
   isBackedUp: false,
   isHapticDisabled: false,
-  isFleetModeEnabled: false,
-  convertHntToCurrency: false,
   isSettingUpHotspot: false,
   isRestored: false,
   isPinRequired: false,
@@ -37,7 +32,6 @@ const initialState: AppState = {
   lastIdle: null,
   isLocked: false,
   isRequestingPermission: false,
-  hasFleetModeAutoEnabled: false,
 }
 
 type Restore = {
@@ -47,11 +41,10 @@ type Restore = {
   authInterval: number
   isLocked: boolean
   isHapticDisabled: boolean
-  convertHntToCurrency: boolean
 }
 
-export const restoreUser = createAsyncThunk<Restore>(
-  'app/restoreUser',
+export const restoreAppSettings = createAsyncThunk<Restore>(
+  'app/restoreAppSettings',
   async () => {
     const [
       isBackedUp,
@@ -59,20 +52,14 @@ export const restoreUser = createAsyncThunk<Restore>(
       isPinRequiredForPayment,
       authInterval,
       isHapticDisabled,
-      convertHntToCurrency,
       address,
-      isFleetModeEnabled,
-      hasFleetModeAutoEnabled,
     ] = await Promise.all([
       getSecureItem('accountBackedUp'),
       getSecureItem('requirePin'),
       getSecureItem('requirePinForPayment'),
       getSecureItem('authInterval'),
       getSecureItem('hapticDisabled'),
-      getSecureItem('convertHntToCurrency'),
       getSecureItem('address'),
-      getSecureItem('fleetModeEnabled'),
-      getSecureItem('hasFleetModeAutoEnabled'),
     ])
 
     if (isBackedUp && address) {
@@ -88,9 +75,6 @@ export const restoreUser = createAsyncThunk<Restore>(
         : Intervals.IMMEDIATELY,
       isLocked: isPinRequired,
       isHapticDisabled,
-      convertHntToCurrency,
-      isFleetModeEnabled,
-      hasFleetModeAutoEnabled,
     } as Restore
   },
 )
@@ -122,25 +106,6 @@ const appSlice = createSlice({
       state.isHapticDisabled = action.payload
       setSecureItem('hapticDisabled', action.payload)
     },
-    updateFleetModeEnabled: (
-      state,
-      action: PayloadAction<{ enabled: boolean; autoEnabled?: boolean }>,
-    ) => {
-      state.isFleetModeEnabled = action.payload.enabled
-      setSecureItem('fleetModeEnabled', action.payload.enabled)
-      if (action.payload.autoEnabled) {
-        state.hasFleetModeAutoEnabled = true
-        setSecureItem('hasFleetModeAutoEnabled', true)
-      }
-    },
-    toggleConvertHntToCurrency: (state) => {
-      state.convertHntToCurrency = !state.convertHntToCurrency
-      setSecureItem('convertHntToCurrency', state.convertHntToCurrency)
-    },
-    updateConvertHntToCurrency: (state, action: PayloadAction<boolean>) => {
-      state.convertHntToCurrency = action.payload
-      setSecureItem('convertHntToCurrency', action.payload)
-    },
     updateAuthInterval: (state, action: PayloadAction<number>) => {
       state.authInterval = action.payload
       setSecureItem('authInterval', action.payload.toString())
@@ -166,7 +131,7 @@ const appSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(restoreUser.fulfilled, (state, { payload }) => {
+    builder.addCase(restoreAppSettings.fulfilled, (state, { payload }) => {
       return { ...state, ...payload, isRestored: true }
     })
   },

--- a/src/utils/useAccountSettings.ts
+++ b/src/utils/useAccountSettings.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect } from 'react'
+import useAppState from 'react-native-appstate-hook'
+import { useSelector } from 'react-redux'
+import accountSlice, {
+  fetchAccountSettings,
+  transferAppSettingsToAccount,
+} from '../store/account/accountSlice'
+import { RootState } from '../store/rootReducer'
+import { useAppDispatch } from '../store/store'
+
+const settingsToTransfer = [
+  'isFleetModeEnabled',
+  'hasFleetModeAutoEnabled',
+  'convertHntToCurrency',
+]
+export default () => {
+  const dispatch = useAppDispatch()
+  const transferRequired = useSelector(
+    (state: RootState) => state.account.settingsTransferRequired,
+  )
+  const accountSettingsLoaded = useSelector(
+    (state: RootState) => state.account.settingsLoaded,
+  )
+  const accountSettings = useSelector(
+    (state: RootState) => state.account.settings,
+  )
+  const accountBackedUp = useSelector(
+    (state: RootState) => state.app.isBackedUp,
+  )
+
+  const refreshAccountSettings = useCallback(
+    () => dispatch(fetchAccountSettings()),
+    [dispatch],
+  )
+
+  useEffect(() => {
+    if (!accountBackedUp) return
+
+    refreshAccountSettings()
+  }, [accountBackedUp, refreshAccountSettings])
+
+  useAppState({
+    onForeground: () => refreshAccountSettings(),
+  })
+
+  useEffect(() => {
+    if (!accountSettingsLoaded || transferRequired !== undefined) return
+
+    const allKeysFoundInApi = settingsToTransfer.every((s) =>
+      Object.keys(accountSettings).includes(s),
+    )
+
+    dispatch(
+      accountSlice.actions.updateSettingsTransferRequired(!allKeysFoundInApi),
+    )
+  }, [accountSettingsLoaded, accountSettings, transferRequired, dispatch])
+
+  useEffect(() => {
+    if (!transferRequired) return
+
+    dispatch(transferAppSettingsToAccount())
+  }, [dispatch, transferRequired])
+}

--- a/src/utils/useCurrency.ts
+++ b/src/utils/useCurrency.ts
@@ -9,8 +9,8 @@ import { OraclePrice } from '@helium/http'
 import { fetchCurrentOraclePrice } from '../store/helium/heliumDataSlice'
 import { RootState } from '../store/rootReducer'
 import { useAppDispatch } from '../store/store'
-import appSlice from '../store/user/appSlice'
 import { currencyType, decimalSeparator, groupSeparator, locale } from './i18n'
+import { updateSetting } from '../store/account/accountSlice'
 
 const useCurrency = () => {
   const { t } = useTranslation()
@@ -21,13 +21,13 @@ const useCurrency = () => {
   )
 
   const convert = useSelector(
-    (state: RootState) => state.app.convertHntToCurrency,
-    isEqual,
+    (state: RootState) => state.account.settings.convertHntToCurrency,
   )
 
   const toggle = useCallback(
-    () => dispatch(appSlice.actions.toggleConvertHntToCurrency()),
-    [dispatch],
+    () =>
+      dispatch(updateSetting({ key: 'convertHntToCurrency', value: !convert })),
+    [convert, dispatch],
   )
 
   const formatCurrency = useCallback(async (value: number) => {


### PR DESCRIPTION
The app-level settings `isFleetModeEnabled`, `hasFleetModeAutoEnabled`, and `convertHntToCurrency` all have been moved to account settings (which is backed by the wallet API). Any app-level settings will now live in `appSlice` and account settings will live in `accountSlice`.