### PR TITLE
fix pod lockfile

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -401,14 +401,14 @@ PODS:
     - Yoga
   - RNScreens (2.18.1):
     - React-Core
-  - RNSentry (2.4.2):
+  - RNSentry (2.6.2):
     - React-Core
-    - Sentry (= 6.1.4)
+    - Sentry (= 7.1.4)
   - RNSVG (12.1.1):
     - React
-  - Sentry (6.1.4):
-    - Sentry/Core (= 6.1.4)
-  - Sentry/Core (6.1.4)
+  - Sentry (7.1.4):
+    - Sentry/Core (= 7.1.4)
+  - Sentry/Core (7.1.4)
   - Toast (4.0.0)
   - UMAppLoader (1.3.0)
   - UMBarCodeScannerInterface (5.3.0)
@@ -696,15 +696,15 @@ SPEC CHECKSUMS:
   EXSecureStore: 1b571851e6068b30b8ec097be848a04603c03bae
   EXSplashScreen: ab5984afcca91e0af6b3138f01a8c47dc4955c51
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 3560256311b67bbddc2ce503625e9edde9a6ee1d
-  glog: 7a8788d88d2a384c05df45e95c5e763e4d81f3ad
+  FBReactNativeSpec: ef7076047ecfe23933320b0fb2b844474516e2e8
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
   lottie-react-native: 4dff8fe8d10ddef9e7880e770080f4a56121397e
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
   MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
   MultiplatformBleAdapter: 975cfb2a333b2c42b7a11628bd100ccb61872da2
   OneSignal: e4dfb1912410f302dc9661ce98fc829f6c18ff6a
-  RCT-Folly: 1af344185a2506dec1e584dd5edaaa8fb6bcda5e
+  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24
@@ -746,9 +746,9 @@ SPEC CHECKSUMS:
   RNLocalize: 7c7aeda16c01db7a0918981c14875c0a53be9b79
   RNReanimated: 64f6c5789f82818c07ba3c71864b73619cb23c76
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  RNSentry: e86fb2e2fec0365644f4b582938bf66be515acce
+  RNSentry: 68644ef607b780551cc555f084869764f2566652
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
-  Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
+  Sentry: 1d3eb1a25f8c5333c88dd5603904a6d461cd9fcf
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   UMAppLoader: 5db5dc03176c6238da9c8b3657a370137882a4ad
   UMBarCodeScannerInterface: 017672479f93de88d94c3a50dfb66b5348b65989


### PR DESCRIPTION
Pod lockfile needed updates after the sentry upgrade to 2.6.2