### PR TITLE
fix android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -233,6 +233,10 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    configurations.all {
+        resolutionStrategy { force 'androidx.work:work-runtime:2.6.0' }
+    }
 }
 
 // Run this once to be able to run the application with BUCK


### PR DESCRIPTION
force androidx.work:work-runtime to 2.6.0, it was updating to a beta version requiring SDK 31 which we don't support yet.