### PR TITLE
Link to hotspotty's in depth reward scale documentation/simulation

### DIFF
--- a/src/components/HotspotListItem.tsx
+++ b/src/components/HotspotListItem.tsx
@@ -164,6 +164,7 @@ const HotspotListItem = ({
                 )}
                 {showRewardScale && (
                   <HexBadge
+                    hotspotId={hotspot.address}
                     rewardScale={hotspot.rewardScale}
                     pressable={false}
                     badge={false}

--- a/src/constants/articles.ts
+++ b/src/constants/articles.ts
@@ -1,6 +1,5 @@
 enum Articles {
   Relay = 'https://docs.helium.com/troubleshooting/network-troubleshooting',
-  Reward_Scaling = 'https://docs.helium.com/blockchain/proof-of-coverage/#poc-reward-scaling',
   Token_Earnings = 'https://docs.helium.com/blockchain/mining/#how-do-hotspots-earn-helium-tokens',
   Helium_Token = 'https://docs.helium.com/blockchain/helium-token',
   Docs_Root = 'https://docs.helium.com',

--- a/src/features/hotspots/details/HexBadge.tsx
+++ b/src/features/hotspots/details/HexBadge.tsx
@@ -11,6 +11,7 @@ import Articles from '../../../constants/articles'
 import { Colors } from '../../../theme/theme'
 
 type Props = {
+  hotspotId?: string
   rewardScale?: number
   pressable?: boolean
   badge?: boolean
@@ -19,6 +20,7 @@ type Props = {
   hitSlop?: Insets
 }
 const HexBadge = ({
+  hotspotId,
   rewardScale,
   pressable = true,
   backgroundColor,
@@ -40,8 +42,9 @@ const HexBadge = ({
           text: t('generic.readMore'),
           style: 'cancel',
           onPress: () => {
-            if (Linking.canOpenURL(Articles.Reward_Scaling))
-              Linking.openURL(Articles.Reward_Scaling)
+            const url = `https://app.hotspotty.net/hotspots/${hotspotId}/reward-scaling`
+            if (Linking.canOpenURL(url))
+              Linking.openURL(url)
           },
         },
       ],

--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -536,6 +536,7 @@ const HotspotDetails = ({
               )}
               <HexBadge
                 hitSlop={hitSlop}
+                hotspotId={hotspot.address}  
                 rewardScale={hotspot.rewardScale}
                 backgroundColor="grayBoxLight"
               />


### PR DESCRIPTION
This PR provides the equivalent of [this PR to the Explorer](https://github.com/helium/explorer/pull/691).

It simply swaps the original  "Read more" link to the static Helium documentation with a dynamic link which provides an in-depth overview of a hotspot's status related to reward scaling (HIP15 + HIP17) which also guides the users towards optimization of the network through collaboration with the rest of the community. An example of this page can be seen [here](https://app.hotspotty.net/hotspots/11Mo1yNoH5pX5uXM7qymvA3c626BWhjCCyJvif2QGWkjocY3AGo/rewards).

The UI/UX of this "Read more" button can be seen below:

https://user-images.githubusercontent.com/3253186/132888472-ea0dffde-7da0-4b1b-96b3-e3cd26640495.mp4

