### PR TITLE
Avoid line endings conversion of gradlew.bat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,0 @@
-# Windows files
-[*.bat]
-end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Windows files should use crlf line endings
-# https://help.github.com/articles/dealing-with-line-endings/
-*.bat text eol=crlf


### PR DESCRIPTION
A fresh clone of this repo shows the file `gradlew.bat` as modified:

```
$ git clone https://github.com/helium/hotspot-app.git && cd hotspot-app/
// ...
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   android/gradlew.bat

```

The reason is a configuration which will convert line endings when the file is placed in the working directory. This conversion in unnecessary, as the file `gradlew.bat` is generated by Gradle's [`wrapper`](https://docs.gradle.org/current/userguide/gradle_wrapper.html) task with the correct line endings. It should not be modified manually. This has already been fixed on react-native's main branch: https://github.com/facebook/react-native/pull/31398