### PR TITLE
ensure confirm location update map shows correct location

### DIFF
--- a/src/features/hotspots/settings/updateHotspot/HotspotLocationPreview.tsx
+++ b/src/features/hotspots/settings/updateHotspot/HotspotLocationPreview.tsx
@@ -26,12 +26,17 @@ const HotspotLocationPreview = ({
 }: Props) => {
   return (
     <Box borderRadius="l" overflow="hidden" height={180}>
-      <Map zoomLevel={13} interactive={false} mapCenter={mapCenter} />
+      <Map
+        zoomLevel={13}
+        interactive={false}
+        mapCenter={mapCenter}
+        cameraBottomOffset={55}
+      />
       <ImageBox
         position="absolute"
         top="50%"
         left="50%"
-        style={{ marginTop: -45, marginLeft: -25 / 2 }}
+        style={{ marginTop: -40, marginLeft: -25 / 2 }}
         width={25}
         height={29}
         source={require('../../../../assets/images/locationWhite.png')}


### PR DESCRIPTION
closes #962 

The last confirm location map was a little off on the placement of the location icon vs where the location coords actually were. It just needed a little bottom padding to line up.