### PR TITLE
Fix white flash

### DIFF
--- a/src/features/wallet/root/WalletView.tsx
+++ b/src/features/wallet/root/WalletView.tsx
@@ -129,9 +129,12 @@ const WalletView = ({
         }
 
         if (isEqual(balanceInfoSplit, nextBalanceInfoSplit)) return
-        animateTransition('WalletView.BalanceInfoUpdated', {
-          enabledOnAndroid: false,
-        })
+        if (!balanceInfoSplit.hasBalance) {
+          // Only animate if they didn't previously have balance info
+          animateTransition('WalletView.BalanceInfoUpdated', {
+            enabledOnAndroid: false,
+          })
+        }
         setBalanceInfoSplit(nextBalanceInfoSplit)
       }
     }


### PR DESCRIPTION
Fix white flash when changing currency type on settings and switching back to wallet tab.