### PR TITLE
add loading ui for hex selection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
     "jest/no-export": "off",
     "import/prefer-default-export": "off",
     "no-use-before-define": "off",
-    "no-console": [2, { "allow": ["warn", "error"] }],
     "@typescript-eslint/no-use-before-define": "off",
     "default-case": "off",
     "quotes": [

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -697,14 +697,14 @@ SPEC CHECKSUMS:
   FBLazyVector: 500821d196c3d1bd10e7e828bc93ce075234080f
   FBReactNativeSpec: 74c869e2cffa2ffec685cd1bac6788c021da6005
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 43737235ae6a21de4f45297f4f73b6420fc2ecb2
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
   lottie-react-native: 4dff8fe8d10ddef9e7880e770080f4a56121397e
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
   MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
-  MultiplatformBleAdapter: ec28c1eac17cdb9ca0ba55ba0c2cad3de8e9c01a
+  MultiplatformBleAdapter: 5a6a897b006764392f9cef785e4360f54fb9477d
   OneSignal: e4dfb1912410f302dc9661ce98fc829f6c18ff6a
-  RCT-Folly: e2636706cc3fded205cf0d380428ec0ea7455f80
+  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 3cc065b52aa18db729268b9bd78a2feffb4d0f91
   RCTTypeSafety: 3c4fc37d5dea452d2ef17324db5504ec2f05083a
   React: 4a00720816c52a213424442954acb7e4b724804a

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -11,7 +11,7 @@ import { followHotspot, unfollowHotspot } from '../store/hotspots/hotspotsSlice'
 import { Theme } from '../theme/theme'
 
 type Props = BoxProps<Theme> & {
-  address: string
+  address?: string
   colors?: { following: string; notFollowing: string }
   handleChange?: (following: boolean) => void
   duration?: number
@@ -31,7 +31,11 @@ const FollowButton = ({
   )
 
   useEffect(() => {
-    setFollowing(!!followedHotspots[address])
+    if (!address) {
+      setFollowing(false)
+    } else {
+      setFollowing(!!followedHotspots[address])
+    }
   }, [followedHotspots, address])
 
   const color = useMemo(() => {
@@ -41,6 +45,7 @@ const FollowButton = ({
   }, [colors, following, followPurple, grayPurple])
 
   const toggleFollowing = useCallback(() => {
+    if (!address) return
     setFollowing(!following)
     handleChange?.(!following)
     if (following) {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -44,6 +44,7 @@ type Props = BoxProps<Theme> & {
   ownedHotspots?: Hotspot[]
   followedHotspots?: Hotspot[]
   selectedHotspot?: Hotspot | Witness
+  selectedHex?: string
   witnesses?: Witness[]
   animationMode?: 'flyTo' | 'easeTo' | 'moveTo'
   animationDuration?: number
@@ -79,6 +80,7 @@ const Map = ({
   followedHotspots,
   showRewardScale,
   cameraBottomOffset,
+  selectedHex,
   ...props
 }: Props) => {
   const colors = useColors()
@@ -156,9 +158,10 @@ const Map = ({
     loadMapBoundsAndZoom()
   }, [])
 
-  const selectedHex = useMemo(() => selectedHotspot?.locationHex, [
-    selectedHotspot?.locationHex,
-  ])
+  const selectedHexId = useMemo(
+    () => selectedHex || selectedHotspot?.locationHex,
+    [selectedHex, selectedHotspot?.locationHex],
+  )
 
   const onHexPress = (id: string) => {
     onHexSelected(id)
@@ -182,7 +185,7 @@ const Map = ({
     const boundsLocations: number[][] = []
     let hotspotCoords: number[] | undefined
 
-    if (mapCenter && !selectedHotspot && !selectedHex) {
+    if (mapCenter && !selectedHotspot && !selectedHexId) {
       boundsLocations.push(mapCenter)
     }
 
@@ -192,8 +195,8 @@ const Map = ({
       boundsLocations.push(hotspotCoords)
     }
 
-    if (selectedHex && !selectedHotspot) {
-      boundsLocations.push(h3ToGeo(selectedHex).reverse())
+    if (selectedHexId && !selectedHotspot) {
+      boundsLocations.push(h3ToGeo(selectedHexId).reverse())
     }
 
     if (hotspotCoords) {
@@ -217,7 +220,7 @@ const Map = ({
     }
 
     return findBounds(boundsLocations, cameraBottomOffset)
-  }, [mapCenter, cameraBottomOffset, selectedHex, selectedHotspot, witnesses])
+  }, [mapCenter, cameraBottomOffset, selectedHexId, selectedHotspot, witnesses])
 
   const defaultCameraSettings = useMemo(() => {
     const centerCoordinate =
@@ -293,7 +296,7 @@ const Map = ({
             bounds={mapBounds}
             mapZoom={mapZoomLevel}
             onHexSelected={onHexPress}
-            selectedHexId={selectedHex}
+            selectedHexId={selectedHexId}
             witnesses={witnesses}
             ownedHotspots={ownedHotspots}
             followedHotspots={followedHotspots}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -15,7 +15,13 @@ import MapboxGL, {
 import { Feature, Point, Position } from 'geojson'
 import { Hotspot, Witness } from '@helium/http'
 import { BoxProps } from '@shopify/restyle'
-import { StyleProp, ViewStyle } from 'react-native'
+import {
+  PixelRatio,
+  Platform,
+  Pressable,
+  StyleProp,
+  ViewStyle,
+} from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { h3ToGeo } from 'h3-js'
 import Config from 'react-native-config'
@@ -31,6 +37,8 @@ import Coverage from './Coverage'
 import { distance } from '../utils/location'
 
 const defaultLngLat = [-122.419418, 37.774929] // San Francisco
+
+export const NO_FEATURES = 'no_features'
 
 type Props = BoxProps<Theme> & {
   onMapMoved?: (coords?: Position) => void
@@ -163,9 +171,12 @@ const Map = ({
     [selectedHex, selectedHotspot?.locationHex],
   )
 
-  const onHexPress = (id: string) => {
-    onHexSelected(id)
-  }
+  const onHexPress = useCallback(
+    (id: string) => {
+      onHexSelected(id)
+    },
+    [onHexSelected],
+  )
 
   useEffect(() => {
     if (loaded && userCoords) {
@@ -182,6 +193,7 @@ const Map = ({
   )
 
   const bounds = useMemo(() => {
+    if (selectedHexId === NO_FEATURES) return
     const boundsLocations: number[][] = []
     let hotspotCoords: number[] | undefined
 
@@ -235,79 +247,112 @@ const Map = ({
     }
   }, [mapCenter, zoomLevel])
 
+  const onPressMap = useCallback(
+    async (event) => {
+      if (selectedHexId !== NO_FEATURES) {
+        onHexPress('')
+      }
+      const { locationX, locationY } = event.nativeEvent
+      let locX = locationX
+      let locY = locationY
+
+      if (Platform.OS === 'android') {
+        locX = locationX * PixelRatio.get()
+        locY = locationY * PixelRatio.get()
+      }
+
+      if (!map.current) return
+      const stuff = await map.current.queryRenderedFeaturesAtPoint(
+        [locX, locY],
+        undefined,
+        ['hexagonFill'],
+      )
+
+      if (!stuff?.features[0]?.properties?.id) {
+        onHexPress(NO_FEATURES)
+      } else {
+        onHexPress(stuff.features[0].properties.id)
+      }
+    },
+    [onHexPress, selectedHexId],
+  )
+
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <Box {...props}>
-      {showNoLocation && (
-        <Box
-          position="absolute"
-          zIndex={100}
-          top={0}
-          left={0}
-          right={0}
-          bottom={250}
-          justifyContent="center"
-          alignItems="center"
-        >
-          <NoLocation color={colors.purpleMain} />
-          <Text variant="h2" color="white" marginTop="m">
-            {t('hotspot_details.no_location_title')}
-          </Text>
-          <Text variant="body2" color="purpleMuted" marginTop="s">
-            {t('hotspot_details.no_location_body')}
-          </Text>
-        </Box>
-      )}
-      <MapboxGL.MapView
-        ref={map}
-        onRegionDidChange={onRegionDidChange}
-        onRegionWillChange={onMapMoving}
-        onDidFinishLoadingMap={onDidFinishLoad}
-        styleURL={Config.MAPBOX_STYLE_URL}
-        style={styles.map}
-        logoEnabled={false}
-        rotateEnabled={false}
-        pitchEnabled={false}
-        scrollEnabled={interactive}
-        zoomEnabled={interactive}
-        compassEnabled={false}
+    <Pressable onPress={onPressMap}>
+      <Box
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
       >
-        {(showUserLocation || currentLocationEnabled) && (
-          <MapboxGL.UserLocation onUpdate={handleUserLocationUpdate}>
-            <MapboxGL.SymbolLayer
-              id="markerLocation"
-              style={styles.markerLocation}
-            />
-          </MapboxGL.UserLocation>
+        {showNoLocation && (
+          <Box
+            position="absolute"
+            zIndex={100}
+            top={0}
+            left={0}
+            right={0}
+            bottom={250}
+            justifyContent="center"
+            alignItems="center"
+          >
+            <NoLocation color={colors.purpleMain} />
+            <Text variant="h2" color="white" marginTop="m">
+              {t('hotspot_details.no_location_title')}
+            </Text>
+            <Text variant="body2" color="purpleMuted" marginTop="s">
+              {t('hotspot_details.no_location_body')}
+            </Text>
+          </Box>
         )}
-        <MapboxGL.Camera
-          ref={camera}
-          maxZoomLevel={maxZoomLevel}
-          minZoomLevel={minZoomLevel}
-          defaultSettings={defaultCameraSettings}
-          bounds={bounds}
-          animationMode={animationMode}
-          animationDuration={animationDuration}
-        />
-        <MapboxGL.Images images={mapImages} />
-        {showNearbyHotspots && (
-          <Coverage
-            showGrid={showH3Grid}
-            bounds={mapBounds}
-            mapZoom={mapZoomLevel}
-            onHexSelected={onHexPress}
-            selectedHexId={selectedHexId}
-            witnesses={witnesses}
-            ownedHotspots={ownedHotspots}
-            followedHotspots={followedHotspots}
-            showRewardScale={showRewardScale}
+        <MapboxGL.MapView
+          ref={map}
+          onRegionDidChange={onRegionDidChange}
+          onRegionWillChange={onMapMoving}
+          onDidFinishLoadingMap={onDidFinishLoad}
+          styleURL={Config.MAPBOX_STYLE_URL}
+          style={styles.map}
+          logoEnabled={false}
+          rotateEnabled={false}
+          pitchEnabled={false}
+          scrollEnabled={interactive}
+          zoomEnabled={interactive}
+          compassEnabled={false}
+        >
+          {(showUserLocation || currentLocationEnabled) && (
+            <MapboxGL.UserLocation onUpdate={handleUserLocationUpdate}>
+              <MapboxGL.SymbolLayer
+                id="markerLocation"
+                style={styles.markerLocation}
+              />
+            </MapboxGL.UserLocation>
+          )}
+          <MapboxGL.Camera
+            ref={camera}
+            maxZoomLevel={maxZoomLevel}
+            minZoomLevel={minZoomLevel}
+            defaultSettings={defaultCameraSettings}
+            bounds={bounds}
+            animationMode={animationMode}
+            animationDuration={animationDuration}
           />
+          <MapboxGL.Images images={mapImages} />
+          {showNearbyHotspots && (
+            <Coverage
+              showGrid={showH3Grid}
+              bounds={mapBounds}
+              mapZoom={mapZoomLevel}
+              selectedHexId={selectedHexId === NO_FEATURES ? '' : selectedHexId}
+              witnesses={witnesses}
+              ownedHotspots={ownedHotspots}
+              followedHotspots={followedHotspots}
+              showRewardScale={showRewardScale}
+            />
+          )}
+        </MapboxGL.MapView>
+        {currentLocationEnabled && (
+          <CurrentLocationButton onPress={centerUserLocation} />
         )}
-      </MapboxGL.MapView>
-      {currentLocationEnabled && (
-        <CurrentLocationButton onPress={centerUserLocation} />
-      )}
-    </Box>
+      </Box>
+    </Pressable>
   )
 }
 

--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -11,6 +11,7 @@ import {
 import { Hotspot, Witness } from '@helium/http'
 import Animated from 'react-native-reanimated'
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet'
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder'
 import Box from '../../../components/Box'
 import Text from '../../../components/Text'
 import StatusBadge from './StatusBadge'
@@ -184,7 +185,7 @@ const HotspotDetails = ({
   }, [updateSyncStatus])
 
   const formattedHotspotName = useMemo(() => {
-    if (!hotspot) return ''
+    if (!hotspot || !hotspot.address) return ''
 
     const name = animalName(hotspot.address)
     const pieces = name.split(' ')
@@ -416,31 +417,49 @@ const HotspotDetails = ({
         <Box paddingBottom="l">
           <Box onLayout={handleHeaderLayout}>
             <Box marginBottom="lm" alignItems="flex-start" marginHorizontal="m">
-              <Text
-                variant="light"
-                fontSize={29}
-                lineHeight={31}
-                color={isHidden ? 'grayLightText' : 'black'}
-                numberOfLines={1}
-                width="100%"
-                adjustsFontSizeToFit
-              >
-                {formattedHotspotName[0]}
-              </Text>
-              <Box flexDirection="row" alignItems="center">
-                <Text
-                  variant="regular"
-                  fontSize={29}
-                  lineHeight={31}
-                  paddingRight="s"
-                  color={isHidden ? 'grayLightText' : 'black'}
-                  numberOfLines={1}
-                  adjustsFontSizeToFit
-                >
-                  {formattedHotspotName[1]}
-                </Text>
-                {isHidden && <VisibilityOff height={20} width={20} />}
-              </Box>
+              {hotspot.address === undefined ? (
+                <SkeletonPlaceholder>
+                  <SkeletonPlaceholder.Item
+                    height={29}
+                    width={250}
+                    borderRadius={spacing.s}
+                  />
+                  <SkeletonPlaceholder.Item
+                    height={29}
+                    marginTop={spacing.xs}
+                    width={150}
+                    borderRadius={spacing.s}
+                  />
+                </SkeletonPlaceholder>
+              ) : (
+                <>
+                  <Text
+                    variant="light"
+                    fontSize={29}
+                    lineHeight={31}
+                    color={isHidden ? 'grayLightText' : 'black'}
+                    numberOfLines={1}
+                    width="100%"
+                    adjustsFontSizeToFit
+                  >
+                    {formattedHotspotName[0]}
+                  </Text>
+                  <Box flexDirection="row" alignItems="center">
+                    <Text
+                      variant="regular"
+                      fontSize={29}
+                      lineHeight={31}
+                      paddingRight="s"
+                      color={isHidden ? 'grayLightText' : 'black'}
+                      numberOfLines={1}
+                      adjustsFontSizeToFit
+                    >
+                      {formattedHotspotName[1]}
+                    </Text>
+                    {isHidden && <VisibilityOff height={20} width={20} />}
+                  </Box>
+                </>
+              )}
             </Box>
             <Box
               flexDirection="row"
@@ -448,6 +467,7 @@ const HotspotDetails = ({
               alignItems="center"
               marginBottom="m"
               marginLeft="m"
+              opacity={hotspot.address === undefined ? 0 : 100}
             >
               <Location
                 width={10}

--- a/src/features/hotspots/root/HotspotSheetHandle.tsx
+++ b/src/features/hotspots/root/HotspotSheetHandle.tsx
@@ -14,9 +14,8 @@ type Props = {
 }
 const HotspotSheetHandle = ({ hotspot, toggleSettings }: Props) => {
   const colors = useColors()
-  const showHotspotOptions = hotspot && hotspot.address
-
-  if (!showHotspotOptions) return null
+  const showHotspotOptions =
+    hotspot !== undefined && hotspot.address !== undefined
   return (
     <Box
       flexDirection="row"
@@ -39,19 +38,22 @@ const HotspotSheetHandle = ({ hotspot, toggleSettings }: Props) => {
       >
         <CardHandle />
       </Box>
-      {showHotspotOptions && hotspot && (
-        <Box flexDirection="row" alignItems="center">
-          <FollowButton address={hotspot.address} />
-          <TouchableOpacityBox
-            onPress={toggleSettings}
-            marginLeft="m"
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <Settings width={22} height={22} color={colors.grayPurple} />
-          </TouchableOpacityBox>
-          <ShareSheet item={hotspot} />
-        </Box>
-      )}
+      <Box
+        flexDirection="row"
+        alignItems="center"
+        opacity={showHotspotOptions ? 100 : 0}
+      >
+        <FollowButton address={hotspot?.address} />
+        <TouchableOpacityBox
+          disabled={!showHotspotOptions}
+          onPress={toggleSettings}
+          marginLeft="m"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Settings width={22} height={22} color={colors.grayPurple} />
+        </TouchableOpacityBox>
+        <ShareSheet item={hotspot} />
+      </Box>
     </Box>
   )
 }

--- a/src/store/activity/activitySlice.ts
+++ b/src/store/activity/activitySlice.ts
@@ -238,7 +238,6 @@ const activitySlice = createSlice({
         }
         state.requestMore = false
         state.txns[filter].status = 'more_rejected'
-        console.error(`Request to fetchMoreTxns with ${filter} was rejected`)
       },
     )
     builder.addCase(
@@ -300,7 +299,6 @@ const activitySlice = createSlice({
           state.txns[filter].hasInitialLoad = true
         }
         state.txns[filter].status = 'rejected'
-        console.error(`Request to fetchTxnsHead with ${filter} was rejected`)
       },
     )
     builder.addCase(

--- a/src/store/discovery/discoverySlice.ts
+++ b/src/store/discovery/discoverySlice.ts
@@ -13,6 +13,7 @@ export type DiscoveryState = {
   selectedRequest?: DiscoveryRequest | null
   requestId?: number | null
   hotspotsForHexId: Record<string, Hotspot[]>
+  loadingHotspotsForHex: boolean
 }
 
 const initialState: DiscoveryState = {
@@ -20,6 +21,7 @@ const initialState: DiscoveryState = {
   requestLoading: 'idle',
   recentDiscoveryInfos: {},
   hotspotsForHexId: {},
+  loadingHotspotsForHex: false,
 }
 
 export const fetchHotspotsForHex = createAsyncThunk<
@@ -119,8 +121,15 @@ const discoverySlice = createSlice({
       fetchHotspotsForHex.fulfilled,
       (state, { meta: { arg }, payload }) => {
         state.hotspotsForHexId[arg.hexId] = payload
+        state.loadingHotspotsForHex = false
       },
     )
+    builder.addCase(fetchHotspotsForHex.pending, (state) => {
+      state.loadingHotspotsForHex = true
+    })
+    builder.addCase(fetchHotspotsForHex.rejected, (state) => {
+      state.loadingHotspotsForHex = false
+    })
   },
 })
 

--- a/src/utils/hotspotUtils.ts
+++ b/src/utils/hotspotUtils.ts
@@ -28,7 +28,7 @@ export const HELIUM_OLD_MAKER_ADDRESS =
   '14fzfjFcHpDR1rTH8BNPvSi5dKBbgxaDnmsVPbCjuq9ENjpZbxh'
 
 export const isHotspot = (item: unknown): item is Hotspot =>
-  (item as Hotspot).location !== undefined &&
+  (item as Hotspot).locationHex !== undefined &&
   (item as Witness).witnessFor === undefined
 
 export const isWitness = (


### PR DESCRIPTION
Changes the hex selection interaction to happen instantly and no longer wait for the `/hotspots/hex/id` call to finish. Because of this I added a loading state to the card itself. I also made it so that while a hex is loading you cant tap to load another, because when things are slow they all pile up and then sporadically load all at once.

closes #1045 