### PR TITLE
disable console for release builds

### DIFF
--- a/src/utils/polyfill.js
+++ b/src/utils/polyfill.js
@@ -11,3 +11,30 @@ if (Platform.OS === 'android') {
 }
 
 global.Buffer = global.Buffer || buffer.Buffer
+
+// eslint-disable-next-line no-undef
+if (!__DEV__) {
+  global.console = {
+    log: () => {},
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+    info: () => {},
+    assert: () => {},
+    clear: () => {},
+    trace: () => {},
+    group: () => {},
+    groupCollapsed: () => {},
+    groupEnd: () => {},
+    timeStamp: () => {},
+    time: () => {},
+    profile: () => {},
+    profileEnd: () => {},
+    count: () => {},
+    dir: () => {},
+    dirxml: () => {},
+    exception: () => {},
+    timeEnd: () => {},
+    table: () => {},
+  }
+}


### PR DESCRIPTION
There are some new warning logs coming from react native for an EventEmitter deprecated call. Many libraries use this call so it gets a bunch of deprecation warning logs.

For this reason I disabled logs in release builds, and we can update they libraries causing the logs when they have a fix.