### PR TITLE
Add QR onboarding and update help text

### DIFF
--- a/src/makers/controllino/hotspots.ts
+++ b/src/makers/controllino/hotspots.ts
@@ -26,7 +26,7 @@ const ControllinoHotspot = {
 } as MakerHotspot
 
 const ControllinoHotspotQR = {
-  name: 'Controllino Hotspot',
+  name: 'Controllino Hotspot QR',
   icon: HotspotIcon,
   onboardType: 'QR',
   translations: {

--- a/src/makers/controllino/hotspots.ts
+++ b/src/makers/controllino/hotspots.ts
@@ -12,11 +12,11 @@ const ControllinoHotspot = {
         '<b><white>Diagnostic support allows Controllino to identify issues with your Hotspot in a secure way.</white></b>\n\nControllino will never have access to private keys and will only ever be able to access your Hotspot and not any other devices on your Network.\n\nIf you would like to opt-out of diagnostic support please email <purple><b>hotspotsupport@controllino.com</b></purple> from the email used to purchase the Hotspot.',
       power: [
         'Attach the antenna and plug in the power cable as described in the user manual.',
-        'Your Hotspot will boot up. The blue LED will blink once for 1 second when done.',
+        'Your Hotspot will boot up. Wait for 5 minutes until the blue LED lights up.',
       ],
       bluetooth: [
-        'After you see the blue LED light up 3 TIMES, press the button below to start pairing.',
-        'If you cannot see it in the app, try scanning again. If it fails multiple times, unplug the power cable and plug it in to start the process again.',
+        'After the Blue LED blinks 3 TIMES, press the button below to start pairing.',
+        'If you cannot see it in the app, try scanning again. If it fails multiple times, turn your bluetooth off and on and retry. If it fails, plug the hotspot out of power and power it again.',
       ],
     },
   },
@@ -25,4 +25,33 @@ const ControllinoHotspot = {
   },
 } as MakerHotspot
 
-export default { ControllinoHotspot }
+const ControllinoHotspotQR = {
+  name: 'Controllino Hotspot',
+  icon: HotspotIcon,
+  onboardType: 'QR',
+  translations: {
+    en: {
+      diagnostic:
+        '<b><white>Diagnostic support allows Controllino to identify issues with your Hotspot in a secure way.</white></b>\n\nControllino will never have access to private keys and will only ever be able to access your Hotspot and not any other devices on your Network.\n\nIf you would like to opt-out of diagnostic support please email <purple><b>helium@controllino.com</b></purple> from the email used to purchase the Hotspot.',
+      power: [
+        'Attach the antenna and plug in the power cable as described in the user manual.',
+        'Your Hotspot will boot up. Wait for 5 minutes until the blue LED lights up.',
+      ],
+      externalOnboard: 'Your onboarding QR Code is included in the package',
+    },
+    ja: {
+      // TODO: Translate strings for diagnostic, power, and bluetooth
+    },
+    ko: {
+      // TODO: Translate strings for diagnostic, power, and bluetooth
+    },
+    zh: {
+      // TODO: Translate strings for diagnostic, power, and bluetooth
+    },
+  },
+  antenna: {
+    default: ANTENNAS.CONTROLLINO_EU,
+  },
+} as MakerHotspot
+
+export default { ControllinoHotspot, ControllinoHotspotQR }


### PR DESCRIPTION
Due to Bluetooth being a bit picky sometimes, we'd like to add QR code onboarding as an additional onboarding option.