### PR TITLE
fix lag when pressing update hotspot button

### DIFF
--- a/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
+++ b/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
@@ -55,7 +55,9 @@ const HotspotDiagnosticsConnection = ({ onConnected }: Props) => {
   const handleConnect = (hotspot: Device) => async () => {
     try {
       setSelectedHotspot(hotspot)
-      const connectStatus = await connectAndConfigHotspot(hotspot, true)
+      const connectStatus = await connectAndConfigHotspot(hotspot, {
+        isDiagnostics: true,
+      })
       const connectHotspotSuccess = connectStatus === 'success'
       setConnected(connectHotspotSuccess)
       if (connectHotspotSuccess) {

--- a/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
+++ b/src/features/hotspots/settings/HotspotDiagnosticsConnection.tsx
@@ -55,7 +55,7 @@ const HotspotDiagnosticsConnection = ({ onConnected }: Props) => {
   const handleConnect = (hotspot: Device) => async () => {
     try {
       setSelectedHotspot(hotspot)
-      const connectStatus = await connectAndConfigHotspot(hotspot)
+      const connectStatus = await connectAndConfigHotspot(hotspot, true)
       const connectHotspotSuccess = connectStatus === 'success'
       setConnected(connectHotspotSuccess)
       if (connectHotspotSuccess) {

--- a/src/features/hotspots/settings/HotspotSettings.tsx
+++ b/src/features/hotspots/settings/HotspotSettings.tsx
@@ -60,11 +60,6 @@ import useAlert from '../../../utils/useAlert'
 import { getLocationPermission } from '../../../store/location/locationSlice'
 import { isDataOnly } from '../../../utils/hotspotUtils'
 import { updateSetting } from '../../../store/account/accountSlice'
-import {
-  fetchTxnsHead,
-  HttpTransaction,
-} from '../../../store/activity/activitySlice'
-import { isPendingTransaction } from '../../wallet/root/useActivityItem'
 
 type State = 'init' | 'scan' | 'transfer' | 'discoveryMode' | 'updateHotspot'
 
@@ -186,27 +181,9 @@ const HotspotSettings = ({ hotspot }: Props) => {
     setNextState('discoveryMode')
   }, [setNextState])
 
-  const onPressUpdateHotspot = useCallback(async () => {
-    // Check for pending assert
-    const pending = (await dispatch(fetchTxnsHead({ filter: 'pending' }))) as {
-      payload?: HttpTransaction[]
-    }
-    const txns = pending.payload
-    const hasPending = txns?.find((pendingTxn) => {
-      if (!isPendingTransaction(pendingTxn)) return
-
-      return (
-        pendingTxn.txn.type === 'assert_location_v2' &&
-        pendingTxn.status === 'pending' &&
-        pendingTxn.txn.gateway === hotspot?.address
-      )
-    })
-    if (hasPending) {
-      Toast.show(t('hotspot_settings.reassert.already_pending'), Toast.LONG)
-    } else {
-      setNextState('updateHotspot')
-    }
-  }, [dispatch, hotspot?.address, setNextState, t])
+  const onPressUpdateHotspot = useCallback(() => {
+    setNextState('updateHotspot')
+  }, [setNextState])
 
   const onPressTransferSetting = useCallback(() => {
     if (hasActiveTransfer) {

--- a/src/utils/useHotspot.ts
+++ b/src/utils/useHotspot.ts
@@ -129,6 +129,7 @@ const useHotspot = () => {
 
   const connectAndConfigHotspot = async (
     hotspotDevice: Device,
+    isDiagnostics?: boolean,
   ): Promise<HotspotConnectStatus> => {
     let connectedDevice = hotspotDevice
     const connected = await hotspotDevice.isConnected()
@@ -178,27 +179,36 @@ const useHotspot = () => {
     Logger.breadcrumb('connectAndConfigHotspot - received details', {
       data: details,
     })
-    const response = await dispatch(fetchConnectedHotspotDetails(details))
-    let payload: AllHotspotDetails | null = null
-    if (response.payload) {
-      payload = response.payload as AllHotspotDetails
-    }
 
-    await updateHotspotStatus(payload?.hotspot)
-
-    if (!payload?.onboardingRecord?.onboardingKey) {
-      let err: HotspotConnectStatus = 'service_unavailable'
-      if (payload?.onboardingRecord?.code === 404) {
-        err = 'no_onboarding_key'
+    try {
+      const response = await dispatch(fetchConnectedHotspotDetails(details))
+      let payload: AllHotspotDetails | null = null
+      if (response.payload) {
+        payload = response.payload as AllHotspotDetails
       }
-      Logger.error(
-        new Error(
-          `Hotspot connect failed: ${err} - error code: ${payload?.onboardingRecord?.code}`,
-        ),
+
+      await updateHotspotStatus(payload?.hotspot)
+
+      if (!payload?.onboardingRecord?.onboardingKey) {
+        let err: HotspotConnectStatus = 'service_unavailable'
+        if (payload?.onboardingRecord?.code === 404) {
+          err = 'no_onboarding_key'
+        }
+        Logger.error(
+          new Error(
+            `Hotspot connect failed: ${err} - error code: ${payload?.onboardingRecord?.code}`,
+          ),
+        )
+        return handleConnectStatus(err)
+      }
+      return handleConnectStatus(
+        payload || isDiagnostics ? 'success' : 'details_fetch_failure',
       )
-      return handleConnectStatus(err)
+    } catch (e) {
+      return handleConnectStatus(
+        isDiagnostics ? 'success' : 'details_fetch_failure',
+      )
     }
-    return handleConnectStatus(payload ? 'success' : 'details_fetch_failure')
   }
 
   const scanForWifiNetworks = async (configured = false) => {

--- a/src/utils/useHotspot.ts
+++ b/src/utils/useHotspot.ts
@@ -129,7 +129,7 @@ const useHotspot = () => {
 
   const connectAndConfigHotspot = async (
     hotspotDevice: Device,
-    isDiagnostics?: boolean,
+    options: { isDiagnostics?: boolean } = {},
   ): Promise<HotspotConnectStatus> => {
     let connectedDevice = hotspotDevice
     const connected = await hotspotDevice.isConnected()
@@ -202,11 +202,11 @@ const useHotspot = () => {
         return handleConnectStatus(err)
       }
       return handleConnectStatus(
-        payload || isDiagnostics ? 'success' : 'details_fetch_failure',
+        payload || options.isDiagnostics ? 'success' : 'details_fetch_failure',
       )
     } catch (e) {
       return handleConnectStatus(
-        isDiagnostics ? 'success' : 'details_fetch_failure',
+        options.isDiagnostics ? 'success' : 'details_fetch_failure',
       )
     }
   }


### PR DESCRIPTION
We are checking for existing pending transactions when tapping the update hotspot item in hotspot settings which is taking a long time to complete now that the API is slow. 

I moved the check to happen when you actually try to submit the transaction instead. Allowing more time for a current pending to clear and also flows better with the UI.

closes #1093 