### PR TITLE
rewards chart and android open link fixes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,17 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+    </queries>
+
     <!-- Add this line if your application always requires BLE. More info can be found on:
       https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions -->
     <uses-feature

--- a/src/utils/appDataClient.ts
+++ b/src/utils/appDataClient.ts
@@ -98,6 +98,7 @@ export const getValidatorRewards = async (
   date: Date = new Date(),
 ) => {
   Logger.breadcrumb('getValidatorRewards', breadcrumbOpts)
+  date.setUTCHours(0, 0, 0, 0)
   const endDate = new Date(date)
   endDate.setDate(date.getDate() - numDaysBack)
   const list = await client
@@ -164,6 +165,7 @@ export const getHotspotRewards = async (
   date: Date = new Date(),
 ) => {
   Logger.breadcrumb('getHotspotRewards', breadcrumbOpts)
+  date.setUTCHours(0, 0, 0, 0)
   const endDate = new Date(date)
   endDate.setDate(date.getDate() - numDaysBack)
   const list = await client


### PR DESCRIPTION
- Makes rewards charts in the app use UTC day
- Fixes Linking.openURL on Android (https://stackoverflow.com/questions/64699801/linking-canopenurl-returning-false-when-targeting-android-30-sdk-on-react-native)