### PR TITLE
fix android QR scan camera aspect ratio

### DIFF
--- a/src/features/hotspots/setup/HotspotSetupExternalScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupExternalScreen.tsx
@@ -216,7 +216,6 @@ const HotspotSetupExternalScreen = () => {
                 onBarCodeScanned={handleBarCodeScanned.callback}
                 ratio="1:1"
                 style={StyleSheet.absoluteFill}
-                useCamera2Api
               />
             </Box>
           </>

--- a/src/features/wallet/scan/ScanView.tsx
+++ b/src/features/wallet/scan/ScanView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useAsync } from 'react-async-hook'
-import { StyleSheet } from 'react-native'
+import { Platform, StyleSheet } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { BarCodeScanner } from 'expo-barcode-scanner'
@@ -10,7 +10,7 @@ import { BarCodeScanningResult, Camera } from 'expo-camera'
 import Box from '../../../components/Box'
 import Text from '../../../components/Text'
 import Crosshair from './Crosshair'
-import { wp } from '../../../utils/layout'
+import { wp, ww } from '../../../utils/layout'
 import Close from '../../../assets/images/close.svg'
 import TouchableOpacityBox from '../../../components/TouchableOpacityBox'
 import useAlert from '../../../utils/useAlert'
@@ -112,6 +112,40 @@ const ScanView = ({ scanType = 'payment', showBottomSheet = true }: Props) => {
     }
   }
 
+  const CameraPreview = () => {
+    if (Platform.OS === 'android') {
+      return (
+        <Box
+          height={ww * (4 / 3)}
+          width={ww}
+          position="absolute"
+          top={30}
+          bottom={0}
+          left={0}
+          right={0}
+        >
+          <Camera
+            onBarCodeScanned={handleBarCodeScanned}
+            barCodeScannerSettings={{
+              barCodeTypes: [BarCodeScanner.Constants.BarCodeType.qr],
+            }}
+            style={StyleSheet.absoluteFillObject}
+            ratio="4:3"
+          />
+        </Box>
+      )
+    }
+    return (
+      <Camera
+        onBarCodeScanned={handleBarCodeScanned}
+        barCodeScannerSettings={{
+          barCodeTypes: [BarCodeScanner.Constants.BarCodeType.qr],
+        }}
+        style={StyleSheet.absoluteFillObject}
+      />
+    )
+  }
+
   if (!permissions) {
     return <Box flex={1} backgroundColor="black" />
   }
@@ -130,15 +164,8 @@ const ScanView = ({ scanType = 'payment', showBottomSheet = true }: Props) => {
   }
 
   return (
-    <Box flex={1}>
-      <Camera
-        onBarCodeScanned={handleBarCodeScanned}
-        barCodeScannerSettings={{
-          barCodeTypes: [BarCodeScanner.Constants.BarCodeType.qr],
-        }}
-        style={StyleSheet.absoluteFillObject}
-        useCamera2Api
-      />
+    <Box flex={1} backgroundColor="black">
+      <CameraPreview />
       <CloseButton onPress={navBack} />
       <Box flex={0.7} justifyContent="center" alignItems="center">
         <Crosshair width={wp(65)} height={wp(65)} color="white" />


### PR DESCRIPTION
- fix camera resolution to 4:3 on Android (it doesnt support dynamic ratios like iOS does)
- revert camera2 change (looks like it was causing an intermittent new crash in expo camera on some Android devices)