### PR TITLE
Fix hotspot not showing when selecting from list or shortcut nav.

### DIFF
--- a/src/features/hotspots/details/HotspotDetails.tsx
+++ b/src/features/hotspots/details/HotspotDetails.tsx
@@ -61,7 +61,6 @@ export type HotspotSnapPoints = { collapsed: number; expanded: number }
 type Props = {
   hotspot?: Hotspot
   onLayoutSnapPoints?: ((snapPoints: HotspotSnapPoints) => void) | undefined
-  onFailure: () => void
   onSelectHotspot: (hotspot: Hotspot) => void
   onChangeHeight: (height: number) => void
   visible: boolean
@@ -72,7 +71,6 @@ const HotspotDetails = ({
   hotspot: propsHotspot,
   onLayoutSnapPoints,
   onSelectHotspot,
-  onFailure,
   visible,
   toggleSettings,
   animatedPosition,
@@ -154,19 +152,6 @@ const HotspotDetails = ({
     const data = getRewardChartData(rewards, timelineValue)
     return data || []
   }, [timelineValue, rewards, visible])
-
-  useEffect(() => {
-    if (!visible) return
-    if (hotspotDetailsData.loading === false && !hotspotDetailsData.hotspot) {
-      // hotspot couldn't be found - likely a bad app link or qr scan
-      onFailure()
-    }
-  }, [
-    visible,
-    hotspotDetailsData.hotspot,
-    hotspotDetailsData.loading,
-    onFailure,
-  ])
 
   // load hotspot data
   useEffect(() => {

--- a/src/features/hotspots/root/HotspotsView.tsx
+++ b/src/features/hotspots/root/HotspotsView.tsx
@@ -460,7 +460,6 @@ const HotspotsView = ({
           hotspot={selectedHotspot}
           onLayoutSnapPoints={setDetailSnapPoints}
           onChangeHeight={setDetailHeight}
-          onFailure={handleItemSelected}
           onSelectHotspot={handlePresentHotspot}
           toggleSettings={toggleSettings}
           animatedPosition={animatedIndex}
@@ -486,7 +485,6 @@ const HotspotsView = ({
     shortcutItem,
     exploreType,
     selectedHotspot,
-    handleItemSelected,
     toggleSettings,
     animatedIndex,
     handleSearching,


### PR DESCRIPTION
Caching was causing the `onFailure` call to trigger when it shouldn't. Fortunately, that call is no longer needed, it was put there to handle bad app links, but that is handled elsewhere.