### PR TITLE
Disable animations setting

### DIFF
--- a/src/features/moreTab/more/MoreScreen.tsx
+++ b/src/features/moreTab/more/MoreScreen.tsx
@@ -60,6 +60,9 @@ const MoreScreen = () => {
   const showHiddenHotspots = useSelector(
     (state: RootState) => state.account.settings.showHiddenHotspots,
   )
+  const animationsEnabled = useSelector(
+    (state: RootState) => state.account.settings.animationsEnabled,
+  )
   const account = useSelector((state: RootState) => state.account, isEqual)
   const fleetModeLowerLimit = useSelector(
     (state: RootState) => state.features.fleetModeLowerLimit,
@@ -189,6 +192,15 @@ const MoreScreen = () => {
       }),
     )
   }, [dispatch, showHiddenHotspots])
+
+  const handleToggleAnimations = useCallback(() => {
+    dispatch(
+      updateSetting({
+        key: 'animationsEnabled',
+        value: !animationsEnabled,
+      }),
+    )
+  }, [dispatch, animationsEnabled])
 
   const handleClearMapCache = useCallback(async () => {
     const decision = await showOKCancelAlert({
@@ -412,6 +424,11 @@ const MoreScreen = () => {
             value: showHiddenHotspots,
           },
           {
+            title: t('more.sections.app.disableAnimations'),
+            onToggle: handleToggleAnimations,
+            value: !animationsEnabled,
+          },
+          {
             title: t('more.sections.app.clearMapCache'),
             onPress: handleClearMapCache,
           },
@@ -446,6 +463,9 @@ const MoreScreen = () => {
     handleFleetMode,
     handleShowHiddenHotspots,
     showHiddenHotspots,
+    handleToggleAnimations,
+    animationsEnabled,
+    handleClearMapCache,
     handleSignOut,
     version,
     authIntervals,
@@ -453,7 +473,6 @@ const MoreScreen = () => {
     handleResetPin,
     handlePinRequiredForPayment,
     showingDeployModeConfirmation,
-    handleClearMapCache,
   ])
 
   const contentContainer = useMemo(

--- a/src/features/onboarding/accountImport/PassphraseAutocomplete.tsx
+++ b/src/features/onboarding/accountImport/PassphraseAutocomplete.tsx
@@ -54,8 +54,8 @@ const PassphraseAutocomplete = ({ onSelectWord, wordIdx }: Props) => {
       behavior="position"
       style={styles.container}
     >
-      <Box marginTop={{ smallPhone: 'm', phone: 'xxl' }}>
-        <Lock />
+      <Box marginTop={{ smallPhone: 's', phone: 'xxl' }}>
+        <Lock height={70} width={70} />
         <Text
           marginTop="l"
           variant="bold"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -587,6 +587,7 @@ export default {
         enableHapticFeedback: 'Enable Haptic Feedback',
         enableFleetMode: 'Enable Fleet Mode',
         showHiddenHotspots: 'Show Hidden Hotspots',
+        disableAnimations: 'Disable Animations',
         convertHntToCurrency: 'Convert HNT to Currency',
         language: 'Language',
         currency: 'Currency',

--- a/src/store/account/accountSlice.ts
+++ b/src/store/account/accountSlice.ts
@@ -23,6 +23,7 @@ const boolKeys = [
   'hasFleetModeAutoEnabled',
   'convertHntToCurrency',
   'showHiddenHotspots',
+  'animationsEnabled',
 ] as const
 type BooleanKey = typeof boolKeys[number]
 const stringKeys = ['hiddenAddresses', 'network', 'currencyType'] as const
@@ -49,6 +50,7 @@ export type AccountState = {
     hasFleetModeAutoEnabled?: boolean
     convertHntToCurrency?: boolean
     showHiddenHotspots?: boolean
+    animationsEnabled?: boolean
     hiddenAddresses?: string
     network?: string
     currencyType?: string
@@ -63,7 +65,7 @@ const initialState: AccountState = {
   activityChart: {} as Record<FilterType, ActivityChart>,
   activityChartRange: 'daily',
   rewardsSum: { loading: true } as CacheRecord<AccountReward>,
-  settings: { network: 'stakejoy', currencyType },
+  settings: { network: 'stakejoy', currencyType, animationsEnabled: true },
   fetchAccountSettingsFailed: false,
 }
 

--- a/src/utils/animateTransition.ts
+++ b/src/utils/animateTransition.ts
@@ -1,5 +1,6 @@
 import { LayoutAnimation, LayoutAnimationConfig, Platform } from 'react-native'
 import Config from 'react-native-config'
+import store from '../store/store'
 
 type AnimationOptions = {
   enabledOnAndroid: boolean
@@ -12,7 +13,11 @@ export default (
     config: LayoutAnimation.Presets.easeInEaseOut,
   },
 ) => {
-  if (Platform.OS === 'android' && !enabledOnAndroid) return
+  const state = store.getState()
+  const { animationsEnabled } = state.account.settings
+
+  if ((Platform.OS === 'android' && !enabledOnAndroid) || !animationsEnabled)
+    return
 
   if (__DEV__ && Config.LOG_ANIMATIONS === 'true') {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
- Adds a disable animations setting which disables all transition animations (native animations still running)
- fixes account import keyboard overlap on small devices
