### PR TITLE
fix keyboard avoiding view reduced motion settings

### DIFF
--- a/patches/react-native+0.66.1.patch
+++ b/patches/react-native+0.66.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js b/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+index 26897f1..dd89f36 100644
+--- a/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
++++ b/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+@@ -73,7 +73,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
+
+   _relativeKeyboardHeight(keyboardFrame): number {
+     const frame = this._frame;
+-    if (!frame || !keyboardFrame) {
++    // with iOS 14 & Reduce Motion > Prefer Cross-Fade Transitions enabled, the keyboard position
++    // & height is reported differently (0 instead of Y position value matching height of frame)
++    if (!frame || !keyboardFrame || keyboardFrame.screenY === 0) {
+       return 0;
+     }
+


### PR DESCRIPTION
- fix keyboard avoiding view collapsing to 0 height with reduced motion settings enabled
 
This is a KeyboardAvoidingView React Native bug https://github.com/facebook/react-native/issues/29974