### PR TITLE
Change Terminology for Light Hotspots

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -973,8 +973,8 @@ export default {
     picker_options: { 7: '7D', 14: '14D', 30: '30D', YTD: 'YTD' },
     picker_prompt: 'Select Range',
     status_data_only: 'Data-Only',
-    status_online: 'Online',
-    status_offline: 'Needs Attention',
+    status_online: 'Active',
+    status_offline: 'Inactive',
     ytd: 'Your Hotspot has earned\n{{number}} HNT since {{date}}',
     status_prompt_online: {
       title: 'Hotspot is online and connected.',


### PR DESCRIPTION
Mirroring changes made to the StatusWidget in Explorer for Light Hotspots, changing "Online" to "Active" and "Needs Attention" to "Inactive".

Justification for the change from "Needs Attention" is that, at least with the current PoC issues, that has been resulting in unnecessary or counterproductive actions, like perpetually power cycling, switching from Ethernet to Wi-Fi, etc. "Inactive" provides the necessary information without implying that action needs to be taken, and it matches what's shown on Explorer.

Note: If this change is merged, the other language files should probably be similarly changed.