### PR TITLE
"Waiting to start" wording improvements

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -341,7 +341,7 @@ export default {
       back: 'Back to Hotspot Pairing',
       wait_error_title: 'Please Try Again',
       wait_error_body:
-        'Hotspot miner is waiting to start. Please try again in a few minutes.',
+        'Hotspot miner is waiting to start. Please try connecting with Ethernet, waiting one hour, then pairing again.',
       add_hotspot_error_body:
         'There was an error constructing the Add Hotspot transaction. Please try again.',
       assert_loc_error_body:


### PR DESCRIPTION
In many cases, connecting the hotspot via Ethernet and leaving it alone for an hour resolves the situation causing the "waiting to start" error, so suggest that in the error body.